### PR TITLE
downgrading to .NET 8

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -20,7 +20,7 @@ jobs:
           - name: Setup .NET
             uses: actions/setup-dotnet@v4
             with:
-              dotnet-version: '9.0.x'
+              dotnet-version: '8.0.x'
           - name: Build Azure Function
             working-directory: './api'
             run: dotnet build api.csproj --configuration Release --output ./output

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '8.0.x'
     - name: Restore .NET
       working-directory: './api'
       run: dotnet restore

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
This pull request includes changes to downgrade the .NET version from 9.0 to 8.0 across different files in the project. The most important changes are as follows:

Changes to .NET version:

* [`.github/workflows/api.yml`](diffhunk://#diff-45219019a341aa9fbd159d7d59f842ce8871e83eba709153b2d2c53769673d39L23-R23): Updated `dotnet-version` from '9.0.x' to '8.0.x' in the setup step for .NET.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L31-R31): Updated `dotnet-version` from '9.0.x' to '8.0.x' in the setup step for .NET.
* [`api/api.csproj`](diffhunk://#diff-7e2a63532ed37da024f28094ed72b29d768f76dfdbdb136de20f0f3d0cad08e9L3-R3): Changed the `TargetFramework` from `net9.0` to `net8.0`.