### PR TITLE
Fixing highlight images in blog posts

### DIFF
--- a/blog/2022-12-21-LoadTesting.mdx
+++ b/blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 # Adding Load Testing to your CI/CD workflows

--- a/blog/2022-12-21-LoadTesting.mdx
+++ b/blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: ../static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 # Adding Load Testing to your CI/CD workflows

--- a/blog/2022-12-21-LoadTesting.mdx
+++ b/blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 # Adding Load Testing to your CI/CD workflows

--- a/blog/2023-02-28-ListReposADO.mdx
+++ b/blog/2023-02-28-ListReposADO.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, PowerShell]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-02-28-ListReposADO/ListADORepos.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-02-28-ListReposADO/ListADORepos.png
 date: 2023-02-28T18:00
 ---
 # List repositories with their sizes in Azure Repos

--- a/blog/2023-04-14-ADOGHRepoMigration.mdx
+++ b/blog/2023-04-14-ADOGHRepoMigration.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, GitHub, Migration]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-04-14-ADOGHRepoMigration/ADOtoGH.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-14-ADOGHRepoMigration/ADOtoGH.jpg
 date: 2023-04-14T12:00
 ---
 # Azure DevOps to GitHub – Repo Migration

--- a/blog/2023-04-23-BuildContactForm.mdx
+++ b/blog/2023-04-23-BuildContactForm.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Functions, GitHub Actions, Azure Communication Services, Azure Static Web Apps]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-04-23-BuildContactForm/ContactForm.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-23-BuildContactForm/ContactForm.jpg
 date: 2023-04-23T18:00
 ---
 

--- a/blog/2023-04-25-GHVerifiedCommits.mdx
+++ b/blog/2023-04-25-GHVerifiedCommits.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Github, Git]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-04-25-GHVerifiedCommits/VerifiedCommits.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-25-GHVerifiedCommits/VerifiedCommits.jpg
 date: 2023-04-25T18:00
 ---
 # Verified Commits in GitHub

--- a/blog/2023-05-05-DaysOpenWorkItemsADO.mdx
+++ b/blog/2023-05-05-DaysOpenWorkItemsADO.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, Azure Boards, Work Items]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-05-05-DaysOpenWorkItemsADO/daysworkitemopen.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-05-05-DaysOpenWorkItemsADO/daysworkitemopen.jpg
 date: 2023-05-05T18:00
 ---
 # How many days work items have been open in Azure Boards

--- a/blog/2023-07-03-SQLAzureWithoutSecrets.mdx
+++ b/blog/2023-07-03-SQLAzureWithoutSecrets.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [SQL Azure, GitHub, Azure Active Directory]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-07-03-SQLAzureWithoutSecrets/SQLAzureWithoutSecrets.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-07-03-SQLAzureWithoutSecrets/SQLAzureWithoutSecrets.jpg
 date: 2023-07-03T18:00
 ---
 # Connecting to SQL Azure without secrets using Azure Active Directory

--- a/blog/2023-09-25-CosmicWorks.mdx
+++ b/blog/2023-09-25-CosmicWorks.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Cosmos DB, Azure OpenAI, Azure Cognitive Search, ASP.NET, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-09-25-CosmicWorks/Diagram.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-09-25-CosmicWorks/Diagram.png
 date: 2023-09-25T18:00
 ---
 

--- a/blog/2023-11-06-ColonesExchangeRate.mdx
+++ b/blog/2023-11-06-ColonesExchangeRate.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [NuGet, .NET Standard, Colones, Exchange Rate, Costa Rica]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2023-11-06-ColonesExchangeRate/Icon.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-11-06-ColonesExchangeRate/Icon.png
 date: 2023-11-06T18:00
 ---
 

--- a/blog/2024-05-05-GitHubDeMayo.mdx
+++ b/blog/2024-05-05-GitHubDeMayo.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [GitHub, Copilot, Actions, Security]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2024-05-05-GitHubDeMayo/GitHubdeMayo.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2024-05-05-GitHubDeMayo/GitHubdeMayo.png
 date: 2024-05-05T18:00
 ---
 

--- a/blog/2024-07-03-CloudDevlopmentEnvironments.mdx
+++ b/blog/2024-07-03-CloudDevlopmentEnvironments.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [GitHub Codespaces, Microsoft DevBox, Cloud Development Environments]
 enableComments: true
 hide_table_of_contents: true
-image: ../static/img/blog/2024-07-03-CloudDevlopmentEnvironments/cde.jpeg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2024-07-03-CloudDevlopmentEnvironments/cde.jpeg
 date: 2024-07-03T18:00
 ---
 

--- a/i18n/es/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 

--- a/i18n/es/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 

--- a/i18n/es/docusaurus-plugin-content-blog/2023-02-28-ListReposADO.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-02-28-ListReposADO.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, PowerShell]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-02-28-ListReposADO/ListADORepos.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-02-28-ListReposADO/ListADORepos.png
 date: 2023-02-28T18:00
 ---
 # Lista los repositorios con sus tamaños en Azure Repos

--- a/i18n/es/docusaurus-plugin-content-blog/2023-04-14-ADOGHRepoMigration.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-04-14-ADOGHRepoMigration.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, GitHub, Migration]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-04-14-ADOGHRepoMigration/ADOtoGH.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-14-ADOGHRepoMigration/ADOtoGH.jpg
 date: 2023-04-14T12:00
 ---
 # Migración de repositorios de Azure DevOps a GitHub

--- a/i18n/es/docusaurus-plugin-content-blog/2023-04-23-BuildContactForm.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-04-23-BuildContactForm.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Functions, GitHub Actions, Azure Communication Services, Azure Static Web Apps]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-04-23-BuildContactForm/ContactForm.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-23-BuildContactForm/ContactForm.jpg
 date: 2023-04-23T18:00
 ---
 # Creación de un formulario de contacto sencillo con Azure

--- a/i18n/es/docusaurus-plugin-content-blog/2023-04-25-GHVerifiedCommits.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-04-25-GHVerifiedCommits.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Github, Git]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-04-25-GHVerifiedCommits/VerifiedCommits.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-25-GHVerifiedCommits/VerifiedCommits.jpg
 date: 2023-04-25T18:00
 ---
 # Commits verificados en GitHub

--- a/i18n/es/docusaurus-plugin-content-blog/2023-05-05-DaysOpenWorkItemsADO.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-05-05-DaysOpenWorkItemsADO.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, Azure Boards, Work Items]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-05-05-DaysOpenWorkItemsADO/daysworkitemopen.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-05-05-DaysOpenWorkItemsADO/daysworkitemopen.jpg
 date: 2023-05-05T18:00
 ---
 # Cuántos días han estado abiertos los elementos de trabajo en Azure Boards

--- a/i18n/es/docusaurus-plugin-content-blog/2023-07-03-SQLAzureWithoutSecrets.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-07-03-SQLAzureWithoutSecrets.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [SQL Azure, GitHub, Azure Active Directory]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-07-03-SQLAzureWithoutSecrets/SQLAzureWithoutSecrets.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-07-03-SQLAzureWithoutSecrets/SQLAzureWithoutSecrets.jpg
 date: 2023-07-03T18:00
 ---
 # Conexión a SQL Azure sin secretos mediante Azure Active Directory

--- a/i18n/es/docusaurus-plugin-content-blog/2023-09-25-CosmicWorks.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-09-25-CosmicWorks.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Cosmos DB, Azure OpenAI, Azure Cognitive Search, ASP.NET, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-09-25-CosmicWorks/Diagram.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-09-25-CosmicWorks/Diagram.png
 date: 2023-09-25T18:00
 ---
 

--- a/i18n/es/docusaurus-plugin-content-blog/2023-11-06-ColonesExchangeRate.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2023-11-06-ColonesExchangeRate.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [NuGet, .NET Standard, Colones, Exchange Rate, Costa Rica]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-11-06-ColonesExchangeRate/Icon.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-11-06-ColonesExchangeRate/Icon.png
 date: 2023-11-06T18:00
 ---
 

--- a/i18n/es/docusaurus-plugin-content-blog/2024-05-05-GitHubDeMayo.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2024-05-05-GitHubDeMayo.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [GitHub, Copilot, Actions, Security]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2024-05-05-GitHubDeMayo/GitHubdeMayo.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2024-05-05-GitHubDeMayo/GitHubdeMayo.png
 date: 2024-05-05T18:00
 ---
 

--- a/i18n/es/docusaurus-plugin-content-blog/2024-07-03-CloudDevlopmentEnvironments.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2024-07-03-CloudDevlopmentEnvironments.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [GitHub Codespaces, Microsoft DevBox, Cloud Development Environments]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2024-07-03-CloudDevlopmentEnvironments/cde.jpeg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2024-07-03-CloudDevlopmentEnvironments/cde.jpeg
 date: 2024-07-03T18:00
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Load Testing, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
+image: pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg
 date: 2022-12-21T18:00
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-02-28-ListReposADO.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-02-28-ListReposADO.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, PowerShell]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-02-28-ListReposADO/ListADORepos.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-02-28-ListReposADO/ListADORepos.png
 date: 2023-02-28T18:00
 ---
 # Listar repositórios com seus tamanhos no Azure Repos

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-04-14-ADOGHRepoMigration.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-04-14-ADOGHRepoMigration.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, GitHub, Migration]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-04-14-ADOGHRepoMigration/ADOtoGH.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-14-ADOGHRepoMigration/ADOtoGH.jpg
 date: 2023-04-14T12:00
 ---
 # Azure DevOps para GitHub – Migração de Repositórios

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-04-23-BuildContactForm.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-04-23-BuildContactForm.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Functions, GitHub Actions, Azure Communication Services, Azure Static Web Apps]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-04-23-BuildContactForm/ContactForm.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-23-BuildContactForm/ContactForm.jpg
 date: 2023-04-23T18:00
 ---
 # Criando um formulário de contato simples com o Azure

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-04-25-GHVerifiedCommits.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-04-25-GHVerifiedCommits.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Github, Git]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-04-25-GHVerifiedCommits/VerifiedCommits.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-04-25-GHVerifiedCommits/VerifiedCommits.jpg
 date: 2023-04-25T18:00
 ---
 # Commits verificados no GitHub

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-05-05-DaysOpenWorkItemsADO.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-05-05-DaysOpenWorkItemsADO.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure DevOps, Azure Boards, Work Items]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-05-05-DaysOpenWorkItemsADO/daysworkitemopen.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-05-05-DaysOpenWorkItemsADO/daysworkitemopen.jpg
 date: 2023-05-05T18:00
 ---
 # Quantos dias os itens de trabalho foram abertos nos Quadros do Azure

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-07-03-SQLAzureWithoutSecrets.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-07-03-SQLAzureWithoutSecrets.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [SQL Azure, GitHub, Azure Active Directory]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-07-03-SQLAzureWithoutSecrets/SQLAzureWithoutSecrets.jpg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-07-03-SQLAzureWithoutSecrets/SQLAzureWithoutSecrets.jpg
 date: 2023-07-03T18:00
 ---
 # Conectando-se ao SQL Azure sem segredos usando o Active Directory do Azure

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-09-25-CosmicWorks.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-09-25-CosmicWorks.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [Azure Cosmos DB, Azure OpenAI, Azure Cognitive Search, ASP.NET, GitHub Actions]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-09-25-CosmicWorks/Diagram.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-09-25-CosmicWorks/Diagram.png
 date: 2023-09-25T18:00
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-blog/2023-11-06-ColonesExchangeRate.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2023-11-06-ColonesExchangeRate.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [NuGet, .NET Standard, Colones, Exchange Rate, Costa Rica]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2023-11-06-ColonesExchangeRate/Icon.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2023-11-06-ColonesExchangeRate/Icon.png
 date: 2023-11-06T18:00
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-blog/2024-05-05-GitHubDeMayo.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2024-05-05-GitHubDeMayo.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [GitHub, Copilot, Actions, Security]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2024-05-05-GitHubDeMayo/GitHubdeMayo.png
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2024-05-05-GitHubDeMayo/GitHubdeMayo.png
 date: 2024-05-05T18:00
 ---
 

--- a/i18n/pt/docusaurus-plugin-content-blog/2024-07-03-CloudDevlopmentEnvironments.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2024-07-03-CloudDevlopmentEnvironments.mdx
@@ -6,7 +6,7 @@ authors: [dsanchezcr]
 tags: [GitHub Codespaces, Microsoft DevBox, Cloud Development Environments]
 enableComments: true
 hide_table_of_contents: true
-image: ../../../static/img/blog/2024-07-03-CloudDevlopmentEnvironments/cde.jpeg
+image: https://raw.githubusercontent.com/dsanchezcr/website/refs/heads/main/static/img/blog/2024-07-03-CloudDevlopmentEnvironments/cde.jpeg
 date: 2024-07-03T18:00
 ---
 

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -6,22 +6,10 @@ export default function Contact() {
     const [email, setEmail] = useState('');
     const [message, setMessage] = useState('');
 
-    var myVar;
-
-    function loadForm() {
-      myVar = setTimeout(showForm, 5000);
-    }
-
     function showDiv() {
       document.getElementById("loader").style.display = "none";
       document.getElementById("emailForm").style.display = "none";
       document.getElementById("myDiv").style.display = "block";
-    }
-
-    function showForm() {
-      document.getElementById("loader").style.display = "none";
-      document.getElementById("emailForm").style.display = "block";
-      document.getElementById("myDiv").style.display = "none";
     }
 
     function showLoader() {
@@ -33,19 +21,29 @@ export default function Contact() {
     const handleSubmit = async (e) => {
       e.preventDefault();
   
-      const data = {
+      const params = new URLSearchParams({
         name: name,
         email: email,
         message: message
-      };
+      });
   
       try {
         showLoader();
-        const response = await fetch("https://dsanchezcr.azurewebsites.net/api/SendEmailFunction", {
+        console.log("Sending data:", params.toString());
+        const response = await fetch(`https://dsanchezcr.azurewebsites.net/api/SendEmailFunction?${params.toString()}`, {
           method: "POST",
-          body: JSON.stringify(data),
-          headers: { "Content-Type": "application/json" },
         });
+        console.log("Response status:", response.status);
+
+        const contentType = response.headers.get("Content-Type");
+        let responseData;
+        if (contentType && contentType.includes("application/json")) {
+          responseData = await response.json();
+        } else {
+          responseData = await response.text();
+        }
+        console.log("Response data:", responseData);
+
         if (!response.ok) {          
           document.getElementById("myDiv").style.display = "block";
           document.getElementById("myDiv").value = "There was an error submitting the form";
@@ -55,9 +53,10 @@ export default function Contact() {
         setName('');
         setEmail('');
         setMessage('');
-        loadForm();
       } catch (error) {
         console.error("There was an error submitting the form", error);
+        document.getElementById("myDiv").style.display = "block";
+        document.getElementById("myDiv").innerText = "There was an error submitting the form. Please try again later.";
       }      
     };
 


### PR DESCRIPTION
This pull request updates the image paths in multiple language versions of a blog post to use a consistent format. The changes ensure that the image paths are correctly referenced across different languages.

Changes to image paths:

* [`blog/2022-12-21-LoadTesting.mdx`](diffhunk://#diff-0b6a4eaad0c007339c00e50ea36ef82619bc78180e313d1d709d271eddeac6dbL9-R9): Updated the image path to use `pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg` instead of a relative path.
* [`i18n/es/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx`](diffhunk://#diff-8a08d90262d368ca305e051ba8941a8e3987ae5f9032a96987d1b61707560692L9-R9): Updated the image path to use `pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg` instead of a relative path.
* [`i18n/pt/docusaurus-plugin-content-blog/2022-12-21-LoadTesting.mdx`](diffhunk://#diff-869eeb4442e286fc0a6a4b4703b77dc11db99d44f633bf6291b783c608cb6629L9-R9): Updated the image path to use `pathname:///img/blog/2022-12-21-LoadTesting/LoadTestingWebApp.jpg` instead of a relative path.