### PR TITLE
Add devcontainer.json for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "David Sanchez Website Dev Container Definition",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+  "remoteUser": "codespace",
+  "features": {
+      "ghcr.io/devcontainers/features/azure-cli:1": {},
+      "ghcr.io/devcontainers/features/powershell:1": {},
+      "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+      "vscode": {
+          "extensions": [
+              "GitHub.copilot",
+              "Github.copilot-chat",
+              "GitHub.vscode-pull-request-github",
+              "streetsidesoftware.code-spell-checker",
+              "streetsidesoftware.code-spell-checker-spanish",
+              "streetsidesoftware.code-spell-checker-portuguese-brazilian"
+          ]
+      }
+  },
+  "forwardPorts": [3000],
+  "postCreateCommand": "npm install"
+}

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Docusaurus Dev Container",
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14",
+  "extensions": [
+    "docusaurus.docusaurus",
+    "esbenp.prettier-vscode"
+  ],
+  "postCreateCommand": "npm install"
+}

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,9 +1,0 @@
-{
-  "name": "Docusaurus Dev Container",
-  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14",
-  "extensions": [
-    "docusaurus.docusaurus",
-    "esbenp.prettier-vscode"
-  ],
-  "postCreateCommand": "npm install"
-}


### PR DESCRIPTION
Fixes #96

Add `devcontainer.json` file for GitHub Codespaces.

* Add a new file `devcontainer.json` to the root of the repository.
* Set the `name` field to "Docusaurus Dev Container".
* Set the `image` field to "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14".
* Include the necessary extensions for Docusaurus: `docusaurus.docusaurus` and `esbenp.prettier-vscode`.
* Add a `postCreateCommand` field with the value "npm install".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dsanchezcr/website/pull/97?shareId=53dbcd5b-57c0-40ee-aa37-376aca41cd57).