### PR TITLE
Updating workflow to close PRs

### DIFF
--- a/.github/workflows/azure-static-web-app.yml
+++ b/.github/workflows/azure-static-web-app.yml
@@ -65,3 +65,14 @@ jobs:
           app_location: 'build'
           api_location: './api'
           output_location: 'build'
+
+  close_pull_request:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: azure/static-web-apps-deploy@v1
+        with:
+          action: 'close'


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions workflow for Azure Static Web Apps to handle the closure of pull requests.

Workflow updates:

* [`.github/workflows/azure-static-web-app.yml`](diffhunk://#diff-df43eba752641468401884fc674f691c1272d5967ae47c6c062ca6e3f1d35a30R68-R78): Added a `close_pull_request` job that runs on `ubuntu-latest` and uses the `azure/static-web-apps-deploy@v1` action with the `close` action to handle closed pull requests. This job is conditionally triggered when the GitHub event is a pull request and the action is `closed`.