### PR TITLE
Enhance Azure Function workflow: add publish step and adjust output d…

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -31,7 +31,10 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Build Azure Function
         working-directory: './api'
-        run: dotnet build api.csproj --configuration Release --output ./output
+        run: dotnet build api.csproj --configuration Release
+      - name: Publish Azure Function
+        working-directory: './api'
+        run: dotnet publish api.csproj --configuration Release --output ./output --no-build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -76,6 +79,6 @@ jobs:
         uses: azure/functions-action@v1
         with:
           app-name: 'dsanchezcr'
-          slot-name: 'Production'
+          slot-name: 'production'
           package: 'api/output'
           publish-profile: ${{ secrets.AZUREFUNCTION_PUBLISHINGPROFILE }}

--- a/api/host.json
+++ b/api/host.json
@@ -13,9 +13,5 @@
             "default": "Information",
             "Microsoft": "Warning"
         }
-    },
-    "extensionBundle": {
-        "id": "Microsoft.Azure.Functions.ExtensionBundle",
-        "version": "[4.*, 5.0.0)"
     }
 }

--- a/api/host.json
+++ b/api/host.json
@@ -1,5 +1,6 @@
 {
     "version": "2.0",
+    "functionTimeout": "00:05:00",
     "logging": {
         "applicationInsights": {
             "samplingSettings": {
@@ -7,6 +8,14 @@
                 "excludedTypes": "Request"
             },
             "enableLiveMetricsFilters": true
+        },
+        "logLevel": {
+            "default": "Information",
+            "Microsoft": "Warning"
         }
+    },
+    "extensionBundle": {
+        "id": "Microsoft.Azure.Functions.ExtensionBundle",
+        "version": "[4.*, 5.0.0)"
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to the Azure Function workflow configuration and updates to the `host.json` file for better functionality and logging. The changes streamline the build and publish process, correct a configuration value, and enhance the runtime settings of the Azure Function.

### Workflow improvements:

* [`.github/workflows/api.yml`](diffhunk://#diff-45219019a341aa9fbd159d7d59f842ce8871e83eba709153b2d2c53769673d39L34-R37): Split the build and publish steps for the Azure Function. The `dotnet build` command now only builds the project, while the `dotnet publish` command handles publishing with the `--no-build` flag. This separation ensures a cleaner and more modular workflow.
* [`.github/workflows/api.yml`](diffhunk://#diff-45219019a341aa9fbd159d7d59f842ce8871e83eba709153b2d2c53769673d39L79-R82): Corrected the casing of the `slot-name` parameter from `Production` to `production` in the deployment step to align with Azure conventions.

### Runtime configuration enhancements:

* [`api/host.json`](diffhunk://#diff-31f894e7cd54e8d10018cf0fd566c273b01b0f67a29f3526415b1f307adb77d3R3-R19): Added `functionTimeout` to set a maximum timeout of 5 minutes for function execution. Configured logging levels to set `default` to `Information` and `Microsoft` to `Warning`. Also added an `extensionBundle` configuration to specify the bundle version range for Azure Functions extensions. These changes improve runtime behavior and logging clarity.