### PR TITLE
Simplify exchange rate display; bump dependency

### DIFF
--- a/i18n/es/docusaurus-plugin-content-pages/exchangerates.js
+++ b/i18n/es/docusaurus-plugin-content-pages/exchangerates.js
@@ -101,11 +101,11 @@ export default function ExchangeRates() {
                     <div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
                         <span>Compra:</span>
-                        <strong>{formatRate(dollarExchangeRate.purchase?.value || dollarExchangeRate.buy)}</strong>
+                        <strong>{formatRate(dollarExchangeRate.purchase)}</strong>
                       </div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0' }}>
                         <span>Venta:</span>
-                        <strong>{formatRate(dollarExchangeRate.sale?.value || dollarExchangeRate.sell)}</strong>
+                        <strong>{formatRate(dollarExchangeRate.sale)}</strong>
                       </div>
                     </div>
                   )}
@@ -129,12 +129,12 @@ export default function ExchangeRates() {
                   {euroExchangeRate && (
                     <div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
-                        <span>Compra:</span>
-                        <strong>{formatRate(euroExchangeRate.purchase?.value || euroExchangeRate.buy)}</strong>
+                        <span>Colones:</span>
+                        <strong>{formatRate(euroExchangeRate.colones)}</strong>
                       </div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0' }}>
-                        <span>Venta:</span>
-                        <strong>{formatRate(euroExchangeRate.sale?.value || euroExchangeRate.sell)}</strong>
+                        <span>Dólares:</span>
+                        <strong>${euroExchangeRate.dollars?.toFixed(4) || 'N/A'}</strong>
                       </div>
                     </div>
                   )}

--- a/i18n/pt/docusaurus-plugin-content-pages/exchangerates.js
+++ b/i18n/pt/docusaurus-plugin-content-pages/exchangerates.js
@@ -101,11 +101,11 @@ export default function ExchangeRates() {
                     <div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
                         <span>Compra:</span>
-                        <strong>{formatRate(dollarExchangeRate.purchase?.value || dollarExchangeRate.buy)}</strong>
+                        <strong>{formatRate(dollarExchangeRate.purchase)}</strong>
                       </div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0' }}>
                         <span>Venda:</span>
-                        <strong>{formatRate(dollarExchangeRate.sale?.value || dollarExchangeRate.sell)}</strong>
+                        <strong>{formatRate(dollarExchangeRate.sale)}</strong>
                       </div>
                     </div>
                   )}
@@ -129,12 +129,12 @@ export default function ExchangeRates() {
                   {euroExchangeRate && (
                     <div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
-                        <span>Compra:</span>
-                        <strong>{formatRate(euroExchangeRate.purchase?.value || euroExchangeRate.buy)}</strong>
+                        <span>Colones:</span>
+                        <strong>{formatRate(euroExchangeRate.colones)}</strong>
                       </div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0' }}>
-                        <span>Venda:</span>
-                        <strong>{formatRate(euroExchangeRate.sale?.value || euroExchangeRate.sell)}</strong>
+                        <span>Dólares:</span>
+                        <strong>${euroExchangeRate.dollars?.toFixed(4) || 'N/A'}</strong>
                       </div>
                     </div>
                   )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@docusaurus/plugin-sitemap": "^3.9.0",
         "@docusaurus/preset-classic": "^3.9.0",
         "@docusaurus/theme-mermaid": "^3.9.0",
-        "@dsanchezcr/colonesexchangerate": "^2.0.2",
+        "@dsanchezcr/colonesexchangerate": "^2.1.0",
         "@giscus/react": "^3.1.0",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
@@ -4117,12 +4117,15 @@
       }
     },
     "node_modules/@dsanchezcr/colonesexchangerate": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dsanchezcr/colonesexchangerate/-/colonesexchangerate-2.0.2.tgz",
-      "integrity": "sha512-25kkQW01nDLlLHQpc4xXgrv87GCCkN8BFziJkNJJQ/0tlrQ1U8pUa3C0uTU/Oyx8FEITUn8MHInEVM2+Y82L4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dsanchezcr/colonesexchangerate/-/colonesexchangerate-2.1.0.tgz",
+      "integrity": "sha512-hOanCJr2nc8TapyopIb4sfvWDlhuIl9NrTS4nXhYfJ+CzpRfQ1ALipOZo+RN2FT3QcLY21n69punRAMDRBcbNw==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.2"
+        "axios": "^1.13.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@giscus/react": {
@@ -6605,6 +6608,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -7397,12 +7401,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -17855,14 +17853,25 @@
         "range-parser": "1.2.0"
       }
     },
+    "node_modules/serve-handler/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/serve-handler/node_modules/mime-db": {
@@ -17887,15 +17896,18 @@
       }
     },
     "node_modules/serve-handler/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/plugin-sitemap": "^3.9.0",
     "@docusaurus/preset-classic": "^3.9.0",
     "@docusaurus/theme-mermaid": "^3.9.0",
-    "@dsanchezcr/colonesexchangerate": "^2.0.2",
+    "@dsanchezcr/colonesexchangerate": "^2.1.0",
     "@giscus/react": "^3.1.0",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
@@ -52,6 +52,9 @@
   },
   "overrides": {
     "lodash-es": "4.17.23",
-    "axios": "1.13.5"
+    "axios": "1.13.5",
+    "serve-handler": {
+      "minimatch": "^10.2.1"
+    }
   }
 }

--- a/src/pages/exchangerates.js
+++ b/src/pages/exchangerates.js
@@ -100,11 +100,11 @@ export default function ExchangeRates() {
                     <div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
                         <span>Buy:</span>
-                        <strong>{formatRate(dollarExchangeRate.purchase?.value || dollarExchangeRate.purchase || dollarExchangeRate.buy)}</strong>
+                        <strong>{formatRate(dollarExchangeRate.purchase)}</strong>
                       </div>
                       <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0' }}>
                         <span>Sell:</span>
-                        <strong>{formatRate(dollarExchangeRate.sale?.value || dollarExchangeRate.sale || dollarExchangeRate.sell)}</strong>
+                        <strong>{formatRate(dollarExchangeRate.sale)}</strong>
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
Update exchange rate rendering to match the new API shape: simplify formatting of dollar purchase/sale fields and change euro section to show Colones and Dollars (using euroExchangeRate.colones and euroExchangeRate.dollars). Apply the same UI changes to English, Spanish and Portuguese pages. Also bump @dsanchezcr/colonesexchangerate to ^2.1.0 in package.json and update lockfile accordingly (package-lock.json updated). Added overrides for serve-handler/minimatch and ensured axios version via overrides.