### PR TITLE
Use platform prop directly, remove filters

### DIFF
--- a/gaming/nintendo-switch/index.mdx
+++ b/gaming/nintendo-switch/index.mdx
@@ -26,8 +26,8 @@ While there's no public API to pull data from, here are my favorite games and re
 
 ### Nintendo Switch 2
 
-<ApiGamingSection platform="nintendo-switch" section="games" filter={(item) => item.platform === 'nintendo-switch-2'} />
+<ApiGamingSection platform="nintendo-switch-2" section="games" />
 
 ### Nintendo Switch
 
-<ApiGamingSection platform="nintendo-switch" section="games" filter={(item) => item.platform === 'nintendo-switch'} />
+<ApiGamingSection platform="nintendo-switch" section="games" />

--- a/i18n/es/docusaurus-plugin-content-docs-gaming/current/nintendo-switch/index.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs-gaming/current/nintendo-switch/index.mdx
@@ -25,8 +25,8 @@ Aunque no hay una API pública para extraer datos, aquí están mis juegos favor
 
 ### Nintendo Switch 2
 
-<ApiGamingSection platform="nintendo-switch" section="games" filter={(item) => item.platform === 'nintendo-switch-2'} />
+<ApiGamingSection platform="nintendo-switch-2" section="games" />
 
 ### Nintendo Switch
 
-<ApiGamingSection platform="nintendo-switch" section="games" filter={(item) => item.platform === 'nintendo-switch'} />
+<ApiGamingSection platform="nintendo-switch" section="games" />

--- a/i18n/pt/docusaurus-plugin-content-docs-gaming/current/nintendo-switch/index.mdx
+++ b/i18n/pt/docusaurus-plugin-content-docs-gaming/current/nintendo-switch/index.mdx
@@ -25,8 +25,8 @@ Embora não haja uma API pública para extrair dados, aqui estão meus jogos fav
 
 ### Nintendo Switch 2
 
-<ApiGamingSection platform="nintendo-switch" section="games" filter={(item) => item.platform === 'nintendo-switch-2'} />
+<ApiGamingSection platform="nintendo-switch-2" section="games" />
 
 ### Nintendo Switch
 
-<ApiGamingSection platform="nintendo-switch" section="games" filter={(item) => item.platform === 'nintendo-switch'} />
+<ApiGamingSection platform="nintendo-switch" section="games" />


### PR DESCRIPTION
Pass the correct platform prop to ApiGamingSection for Nintendo Switch 2 and remove redundant filter props from the Nintendo Switch sections. The same fix is applied to the Spanish and Portuguese docs. This simplifies the component usage by relying on the platform prop for filtering.