### PR TITLE
Add Cosmos DB content manager WPF app

### DIFF
--- a/cosmos-manager/App.xaml
+++ b/cosmos-manager/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="CosmosManager.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:CosmosManager"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/cosmos-manager/App.xaml.cs
+++ b/cosmos-manager/App.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace CosmosManager;
+
+/// <summary>
+/// Interaction logic for App.xaml
+/// </summary>
+public partial class App : Application
+{
+}
+

--- a/cosmos-manager/AssemblyInfo.cs
+++ b/cosmos-manager/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/cosmos-manager/Converters/Converters.cs
+++ b/cosmos-manager/Converters/Converters.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CosmosManager.Converters;
+
+public class BoolToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+            return b ? Visibility.Visible : Visibility.Collapsed;
+        return Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value is Visibility v && v == Visibility.Visible;
+}
+
+public class InverseBoolToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+            return b ? Visibility.Collapsed : Visibility.Visible;
+        return Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value is Visibility v && v == Visibility.Collapsed;
+}
+
+public class NullToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value != null ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/cosmos-manager/CosmosManager.csproj
+++ b/cosmos-manager/CosmosManager.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/cosmos-manager/MainWindow.xaml
+++ b/cosmos-manager/MainWindow.xaml
@@ -1,0 +1,272 @@
+﻿<Window x:Class="CosmosManager.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:conv="clr-namespace:CosmosManager.Converters"
+        mc:Ignorable="d"
+        Title="Cosmos DB Content Manager — dsanchezcr.com" Height="800" Width="1200"
+        WindowStartupLocation="CenterScreen">
+    <Window.Resources>
+        <conv:BoolToVisibilityConverter x:Key="BoolToVis"/>
+        <conv:InverseBoolToVisibilityConverter x:Key="InverseBoolToVis"/>
+        <conv:NullToVisibilityConverter x:Key="NullToVis"/>
+        <Style x:Key="ActionButton" TargetType="Button">
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="Margin" Value="4,0"/>
+            <Setter Property="MinWidth" Value="80"/>
+        </Style>
+        <Style x:Key="SectionHeader" TargetType="TextBlock">
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Margin" Value="0,0,0,6"/>
+        </Style>
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Connection Bar -->
+        <Border Grid.Row="0" Background="#F0F0F0" Padding="10" BorderBrush="#CCC" BorderThickness="0,0,0,1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="160"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Endpoint:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBox Grid.Column="1" Text="{Binding Endpoint, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,10,0" VerticalContentAlignment="Center"/>
+                <TextBlock Grid.Column="2" Text="Key:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <PasswordBox Grid.Column="3" x:Name="KeyBox" Margin="0,0,10,0" VerticalContentAlignment="Center" PasswordChanged="KeyBox_PasswordChanged"/>
+                <TextBlock Grid.Column="4" Text="DB:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBox Grid.Column="5" Text="{Binding DatabaseName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,10,0" VerticalContentAlignment="Center"/>
+                <StackPanel Grid.Column="6" Orientation="Horizontal">
+                    <Button Content="Connect" Command="{Binding ConnectCommand}" Style="{StaticResource ActionButton}"
+                            Visibility="{Binding IsConnected, Converter={StaticResource InverseBoolToVis}}"/>
+                    <Button Content="Disconnect" Command="{Binding DisconnectCommand}" Style="{StaticResource ActionButton}"
+                            Visibility="{Binding IsConnected, Converter={StaticResource BoolToVis}}"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1">
+            <!-- Tabs when connected -->
+            <TabControl Visibility="{Binding IsConnected, Converter={StaticResource BoolToVis}}" Margin="6">
+
+                <!-- Movies Tab -->
+                <TabItem Header="🎬 Movies">
+                    <Grid Margin="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <TextBlock Text="Category:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ComboBox ItemsSource="{Binding MovieCategories}" SelectedItem="{Binding SelectedMovieCategory}" Width="160" Margin="0,0,8,0" IsEditable="True"/>
+                            <Button Content="Load" Command="{Binding LoadMoviesCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="+ New" Command="{Binding NewMovieCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Edit" Command="{Binding EditMovieCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Delete" Command="{Binding DeleteMovieCommand}" Style="{StaticResource ActionButton}" Foreground="Red"/>
+                        </StackPanel>
+                        <DataGrid Grid.Row="1" ItemsSource="{Binding Movies}" SelectedItem="{Binding SelectedMovie}"
+                                  AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single"
+                                  GridLinesVisibility="Horizontal" AlternatingRowBackground="#F9F9F9"
+                                  CanUserSortColumns="True" CanUserResizeColumns="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="220"/>
+                                <DataGridTextColumn Header="Title ID (IMDb)" Binding="{Binding TitleId}" Width="120"/>
+                                <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120"/>
+                                <DataGridTextColumn Header="Rating" Binding="{Binding MyRating}" Width="70"/>
+                                <DataGridTextColumn Header="Order" Binding="{Binding Order}" Width="60"/>
+                                <DataGridTextColumn Header="Review (EN)" Binding="{Binding Review.En}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+
+                <!-- Series Tab -->
+                <TabItem Header="📺 Series">
+                    <Grid Margin="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <TextBlock Text="Category:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ComboBox ItemsSource="{Binding SeriesCategories}" SelectedItem="{Binding SelectedSeriesCategory}" Width="160" Margin="0,0,8,0" IsEditable="True"/>
+                            <Button Content="Load" Command="{Binding LoadSeriesCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="+ New" Command="{Binding NewSeriesCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Edit" Command="{Binding EditSeriesCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Delete" Command="{Binding DeleteSeriesCommand}" Style="{StaticResource ActionButton}" Foreground="Red"/>
+                        </StackPanel>
+                        <DataGrid Grid.Row="1" ItemsSource="{Binding Series}" SelectedItem="{Binding SelectedSeries}"
+                                  AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single"
+                                  GridLinesVisibility="Horizontal" AlternatingRowBackground="#F9F9F9"
+                                  CanUserSortColumns="True" CanUserResizeColumns="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="220"/>
+                                <DataGridTextColumn Header="Title ID (IMDb)" Binding="{Binding TitleId}" Width="120"/>
+                                <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="120"/>
+                                <DataGridTextColumn Header="Rating" Binding="{Binding MyRating}" Width="70"/>
+                                <DataGridTextColumn Header="Order" Binding="{Binding Order}" Width="60"/>
+                                <DataGridTextColumn Header="Review (EN)" Binding="{Binding Review.En}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+
+                <!-- Gaming Tab -->
+                <TabItem Header="🎮 Gaming">
+                    <Grid Margin="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <TextBlock Text="Platform:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ComboBox ItemsSource="{Binding GamingPlatforms}" SelectedItem="{Binding SelectedGamingPlatform}" Width="160" Margin="0,0,8,0"/>
+                            <Button Content="Load" Command="{Binding LoadGamingCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="+ New" Command="{Binding NewGamingCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Edit" Command="{Binding EditGamingCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Delete" Command="{Binding DeleteGamingCommand}" Style="{StaticResource ActionButton}" Foreground="Red"/>
+                        </StackPanel>
+                        <DataGrid Grid.Row="1" ItemsSource="{Binding GamingItems}" SelectedItem="{Binding SelectedGaming}"
+                                  AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single"
+                                  GridLinesVisibility="Horizontal" AlternatingRowBackground="#F9F9F9"
+                                  CanUserSortColumns="True" CanUserResizeColumns="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="180"/>
+                                <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="200"/>
+                                <DataGridTextColumn Header="Platform" Binding="{Binding Platform}" Width="100"/>
+                                <DataGridTextColumn Header="Section" Binding="{Binding Section}" Width="100"/>
+                                <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="70"/>
+                                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="90"/>
+                                <DataGridTextColumn Header="Order" Binding="{Binding Order}" Width="60"/>
+                                <DataGridCheckBoxColumn Header="Co-Op" Binding="{Binding CoOp}" Width="55"/>
+                                <DataGridCheckBoxColumn Header="Online" Binding="{Binding Online}" Width="55"/>
+                                <DataGridTextColumn Header="Image URL" Binding="{Binding ImageUrl}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+
+                <!-- Parks Tab -->
+                <TabItem Header="🏰 Parks">
+                    <Grid Margin="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <TextBlock Text="Provider:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ComboBox ItemsSource="{Binding ParkProviders}" SelectedItem="{Binding SelectedParkProvider}" Width="160" Margin="0,0,8,0"/>
+                            <Button Content="Load" Command="{Binding LoadParksCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="+ New" Command="{Binding NewParkCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Edit" Command="{Binding EditParkCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Delete" Command="{Binding DeleteParkCommand}" Style="{StaticResource ActionButton}" Foreground="Red"/>
+                        </StackPanel>
+                        <DataGrid Grid.Row="1" ItemsSource="{Binding Parks}" SelectedItem="{Binding SelectedPark}"
+                                  AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single"
+                                  GridLinesVisibility="Horizontal" AlternatingRowBackground="#F9F9F9"
+                                  CanUserSortColumns="True" CanUserResizeColumns="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="220"/>
+                                <DataGridTextColumn Header="Provider" Binding="{Binding Provider}" Width="100"/>
+                                <DataGridTextColumn Header="Park ID" Binding="{Binding ParkId}" Width="150"/>
+                                <DataGridTextColumn Header="Name (EN)" Binding="{Binding Name.En}" Width="200"/>
+                                <DataGridTextColumn Header="Description (EN)" Binding="{Binding Description.En}" Width="*"/>
+                                <DataGridTextColumn Header="Items Count" Binding="{Binding Items.Count}" Width="90"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+
+                <!-- Monthly Updates Tab -->
+                <TabItem Header="📅 Monthly Updates">
+                    <Grid Margin="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <TextBlock Text="Month:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ComboBox ItemsSource="{Binding MonthlyUpdateMonths}" SelectedItem="{Binding SelectedMonth}" Width="160" Margin="0,0,8,0" IsEditable="True"/>
+                            <Button Content="Load" Command="{Binding LoadMonthlyUpdatesCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="+ New" Command="{Binding NewMonthlyUpdateCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Edit" Command="{Binding EditMonthlyUpdateCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Delete" Command="{Binding DeleteMonthlyUpdateCommand}" Style="{StaticResource ActionButton}" Foreground="Red"/>
+                        </StackPanel>
+                        <DataGrid Grid.Row="1" ItemsSource="{Binding MonthlyUpdates}" SelectedItem="{Binding SelectedMonthlyUpdate}"
+                                  AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single"
+                                  GridLinesVisibility="Horizontal" AlternatingRowBackground="#F9F9F9"
+                                  CanUserSortColumns="True" CanUserResizeColumns="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="180"/>
+                                <DataGridTextColumn Header="Month" Binding="{Binding Month}" Width="90"/>
+                                <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="200"/>
+                                <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="100"/>
+                                <DataGridTextColumn Header="Release Date" Binding="{Binding ReleaseDate}" Width="100"/>
+                                <DataGridTextColumn Header="Platforms" Binding="{Binding Platforms}" Width="120"/>
+                                <DataGridTextColumn Header="Order" Binding="{Binding Order}" Width="60"/>
+                                <DataGridTextColumn Header="YouTube" Binding="{Binding YoutubeVideoId}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+
+            </TabControl>
+
+            <!-- Not connected message -->
+            <StackPanel Visibility="{Binding IsConnected, Converter={StaticResource InverseBoolToVis}}"
+                        VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock Text="Cosmos DB Content Manager" FontSize="24" FontWeight="Light" HorizontalAlignment="Center" Margin="0,0,0,10"/>
+                <TextBlock Text="Enter your Cosmos DB endpoint and key above to connect." FontSize="14" Foreground="Gray" HorizontalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- JSON Editor Overlay -->
+            <Border Visibility="{Binding IsJsonEditorOpen, Converter={StaticResource BoolToVis}}"
+                    Background="#E0000000">
+                <Border Background="White" CornerRadius="8" Margin="40" Padding="20"
+                        VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+                        Effect="{x:Null}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Grid.Row="0" Text="{Binding JsonEditorTitle}" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,10"/>
+                        <TextBox Grid.Row="1" Text="{Binding JsonEditorContent, UpdateSourceTrigger=PropertyChanged}"
+                                 AcceptsReturn="True" AcceptsTab="True" VerticalScrollBarVisibility="Auto"
+                                 HorizontalScrollBarVisibility="Auto" FontFamily="Consolas" FontSize="13"
+                                 TextWrapping="NoWrap"/>
+                        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                            <Button Content="Cancel" Command="{Binding CancelJsonEditorCommand}" Style="{StaticResource ActionButton}"/>
+                            <Button Content="Save" Command="{Binding SaveJsonCommand}" Style="{StaticResource ActionButton}" FontWeight="SemiBold"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Border>
+
+            <!-- Busy Overlay -->
+            <Border Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"
+                    Background="#40000000">
+                <TextBlock Text="Loading..." FontSize="18" Foreground="White"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+        </Grid>
+
+        <!-- Status Bar -->
+        <Border Grid.Row="2" Background="#F0F0F0" Padding="10,6" BorderBrush="#CCC" BorderThickness="0,1,0,0">
+            <TextBlock Text="{Binding StatusMessage}" FontSize="12"/>
+        </Border>
+    </Grid>
+</Window>

--- a/cosmos-manager/MainWindow.xaml.cs
+++ b/cosmos-manager/MainWindow.xaml.cs
@@ -1,0 +1,21 @@
+﻿using System.Windows;
+using CosmosManager.ViewModels;
+
+namespace CosmosManager;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        DataContext = new MainViewModel();
+    }
+
+    private void KeyBox_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is MainViewModel vm)
+        {
+            vm.Key = KeyBox.Password;
+        }
+    }
+}

--- a/cosmos-manager/Models/ContentDocuments.cs
+++ b/cosmos-manager/Models/ContentDocuments.cs
@@ -1,0 +1,213 @@
+using System.Text.Json.Serialization;
+
+namespace CosmosManager.Models;
+
+public abstract class ContentDocument
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+}
+
+public class MovieDocument : ContentDocument
+{
+    [JsonPropertyName("titleId")]
+    public string TitleId { get; set; } = string.Empty;
+
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("myRating")]
+    public double? MyRating { get; set; }
+
+    [JsonPropertyName("review")]
+    public LocalizedText? Review { get; set; }
+
+    [JsonPropertyName("order")]
+    public int? Order { get; set; }
+}
+
+public class SeriesDocument : ContentDocument
+{
+    [JsonPropertyName("titleId")]
+    public string TitleId { get; set; } = string.Empty;
+
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("myRating")]
+    public double? MyRating { get; set; }
+
+    [JsonPropertyName("review")]
+    public LocalizedText? Review { get; set; }
+
+    [JsonPropertyName("order")]
+    public int? Order { get; set; }
+}
+
+public class GamingDocument : ContentDocument
+{
+    [JsonPropertyName("platform")]
+    public string Platform { get; set; } = string.Empty;
+
+    [JsonPropertyName("section")]
+    public string Section { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "card";
+
+    [JsonPropertyName("title")]
+    public object? Title { get; set; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("imageUrl")]
+    public string? ImageUrl { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("recommendation")]
+    public object? Recommendation { get; set; }
+
+    [JsonPropertyName("description")]
+    public object? Description { get; set; }
+
+    [JsonPropertyName("coOp")]
+    public bool? CoOp { get; set; }
+
+    [JsonPropertyName("online")]
+    public bool? Online { get; set; }
+
+    [JsonPropertyName("games")]
+    public List<GamingChildEntry>? Games { get; set; }
+
+    [JsonPropertyName("order")]
+    public int Order { get; set; }
+}
+
+public class GamingChildEntry
+{
+    [JsonPropertyName("title")]
+    public object? Title { get; set; }
+
+    [JsonPropertyName("platform")]
+    public string? Platform { get; set; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("imageUrl")]
+    public string? ImageUrl { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("recommendation")]
+    public object? Recommendation { get; set; }
+
+    [JsonPropertyName("description")]
+    public object? Description { get; set; }
+
+    [JsonPropertyName("coOp")]
+    public bool? CoOp { get; set; }
+
+    [JsonPropertyName("online")]
+    public bool? Online { get; set; }
+}
+
+public class ParkDocument : ContentDocument
+{
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = string.Empty;
+
+    [JsonPropertyName("parkId")]
+    public string ParkId { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public LocalizedText? Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public LocalizedText? Description { get; set; }
+
+    [JsonPropertyName("mapCenter")]
+    public double[]? MapCenter { get; set; }
+
+    [JsonPropertyName("mapZoom")]
+    public double? MapZoom { get; set; }
+
+    [JsonPropertyName("items")]
+    public List<ParkItem>? Items { get; set; }
+}
+
+public class ParkItem
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public LocalizedText? Name { get; set; }
+
+    [JsonPropertyName("review")]
+    public LocalizedText? Review { get; set; }
+
+    [JsonPropertyName("tips")]
+    public LocalizedText? Tips { get; set; }
+
+    [JsonPropertyName("rating")]
+    public int? Rating { get; set; }
+
+    [JsonPropertyName("mustDo")]
+    public bool? MustDo { get; set; }
+
+    [JsonPropertyName("coordinates")]
+    public double[]? Coordinates { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("order")]
+    public int? Order { get; set; }
+}
+
+public class MonthlyUpdateDocument : ContentDocument
+{
+    [JsonPropertyName("month")]
+    public string Month { get; set; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public object? Title { get; set; }
+
+    [JsonPropertyName("releaseDate")]
+    public string? ReleaseDate { get; set; }
+
+    [JsonPropertyName("description")]
+    public object? Description { get; set; }
+
+    [JsonPropertyName("platforms")]
+    public string? Platforms { get; set; }
+
+    [JsonPropertyName("youtubeVideoId")]
+    public string? YoutubeVideoId { get; set; }
+
+    [JsonPropertyName("youtubeTitle")]
+    public object? YoutubeTitle { get; set; }
+
+    [JsonPropertyName("imageUrl")]
+    public string? ImageUrl { get; set; }
+
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = "upcoming";
+
+    [JsonPropertyName("order")]
+    public int Order { get; set; }
+
+    [JsonPropertyName("heroImageUrl")]
+    public string? HeroImageUrl { get; set; }
+
+    [JsonPropertyName("introText")]
+    public object? IntroText { get; set; }
+}

--- a/cosmos-manager/Models/LocalizedText.cs
+++ b/cosmos-manager/Models/LocalizedText.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace CosmosManager.Models;
+
+public class LocalizedText
+{
+    [JsonPropertyName("en")]
+    public string? En { get; set; }
+
+    [JsonPropertyName("es")]
+    public string? Es { get; set; }
+
+    [JsonPropertyName("pt")]
+    public string? Pt { get; set; }
+
+    public override string ToString() => En ?? Es ?? Pt ?? string.Empty;
+}

--- a/cosmos-manager/Services/CosmosManagerService.cs
+++ b/cosmos-manager/Services/CosmosManagerService.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+using CosmosManager.Models;
+
+namespace CosmosManager.Services;
+
+public class CosmosManagerService : IDisposable
+{
+    private readonly CosmosClient _client;
+    private readonly string _databaseName;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public const string MoviesContainer = "content-movies";
+    public const string SeriesContainer = "content-series";
+    public const string GamingContainer = "content-gaming";
+    public const string ParksContainer = "content-parks";
+    public const string MonthlyUpdatesContainer = "content-monthly-updates";
+
+    public CosmosManagerService(string endpoint, string key, string databaseName)
+    {
+        var options = new CosmosClientOptions
+        {
+            UseSystemTextJsonSerializerWithOptions = JsonOptions,
+            ConnectionMode = ConnectionMode.Gateway
+        };
+        _client = new CosmosClient(endpoint, key, options);
+        _databaseName = databaseName;
+    }
+
+    private Container GetContainer(string containerName) =>
+        _client.GetContainer(_databaseName, containerName);
+
+    // ── Generic CRUD ──
+
+    public async Task<List<T>> GetAllAsync<T>(string containerName, string? partitionKeyFilter = null, string? partitionKeyField = null)
+    {
+        var container = GetContainer(containerName);
+        var results = new List<T>();
+
+        QueryDefinition query;
+        QueryRequestOptions? options = null;
+
+        if (!string.IsNullOrEmpty(partitionKeyFilter) && !string.IsNullOrEmpty(partitionKeyField))
+        {
+            query = new QueryDefinition($"SELECT * FROM c WHERE c.{partitionKeyField} = @pk")
+                .WithParameter("@pk", partitionKeyFilter);
+            options = new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKeyFilter) };
+        }
+        else
+        {
+            query = new QueryDefinition("SELECT * FROM c");
+        }
+
+        using var iterator = container.GetItemQueryIterator<T>(query, requestOptions: options);
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            results.AddRange(response);
+        }
+
+        return results;
+    }
+
+    public async Task<T> CreateAsync<T>(string containerName, T item, string partitionKeyValue) where T : ContentDocument
+    {
+        var container = GetContainer(containerName);
+        var response = await container.CreateItemAsync(item, new PartitionKey(partitionKeyValue));
+        return response.Resource;
+    }
+
+    public async Task<T> UpdateAsync<T>(string containerName, T item, string partitionKeyValue) where T : ContentDocument
+    {
+        var container = GetContainer(containerName);
+        var response = await container.ReplaceItemAsync(item, item.Id, new PartitionKey(partitionKeyValue));
+        return response.Resource;
+    }
+
+    public async Task DeleteAsync(string containerName, string id, string partitionKeyValue)
+    {
+        var container = GetContainer(containerName);
+        await container.DeleteItemAsync<object>(id, new PartitionKey(partitionKeyValue));
+    }
+
+    // ── JSON helpers for raw editing ──
+
+    public async Task<string> GetItemJsonAsync(string containerName, string id, string partitionKeyValue)
+    {
+        var container = GetContainer(containerName);
+        var response = await container.ReadItemStreamAsync(id, new PartitionKey(partitionKeyValue));
+        using var reader = new StreamReader(response.Content);
+        var raw = await reader.ReadToEndAsync();
+        // Re-format with indentation
+        using var doc = JsonDocument.Parse(raw);
+        return JsonSerializer.Serialize(doc, JsonOptions);
+    }
+
+    public async Task SaveItemJsonAsync(string containerName, string json, string partitionKeyValue)
+    {
+        var container = GetContainer(containerName);
+        using var doc = JsonDocument.Parse(json);
+        var id = doc.RootElement.GetProperty("id").GetString()
+                 ?? throw new InvalidOperationException("JSON must contain an 'id' property.");
+        using var stream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(stream, doc, JsonOptions);
+        stream.Position = 0;
+        await container.ReplaceItemStreamAsync(stream, id, new PartitionKey(partitionKeyValue));
+    }
+
+    public async Task CreateItemFromJsonAsync(string containerName, string json, string partitionKeyValue)
+    {
+        var container = GetContainer(containerName);
+        using var stream = new MemoryStream();
+        using var doc = JsonDocument.Parse(json);
+        await JsonSerializer.SerializeAsync(stream, doc, JsonOptions);
+        stream.Position = 0;
+        await container.CreateItemStreamAsync(stream, new PartitionKey(partitionKeyValue));
+    }
+
+    // ── Distinct values ──
+
+    public async Task<List<string>> GetDistinctValuesAsync(string containerName, string fieldName)
+    {
+        var container = GetContainer(containerName);
+        var query = new QueryDefinition($"SELECT DISTINCT VALUE c.{fieldName} FROM c");
+        var results = new List<string>();
+
+        using var iterator = container.GetItemQueryIterator<string>(query);
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            results.AddRange(response);
+        }
+
+        return results.OrderBy(v => v).ToList();
+    }
+
+    public async Task<bool> TestConnectionAsync()
+    {
+        var database = _client.GetDatabase(_databaseName);
+        await database.ReadAsync();
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/cosmos-manager/ViewModels/MainViewModel.cs
+++ b/cosmos-manager/ViewModels/MainViewModel.cs
@@ -1,0 +1,487 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CosmosManager.Models;
+using CosmosManager.Services;
+
+namespace CosmosManager.ViewModels;
+
+public partial class MainViewModel : ObservableObject
+{
+    private CosmosManagerService? _service;
+
+    [ObservableProperty] private string endpoint = string.Empty;
+    [ObservableProperty] private string key = string.Empty;
+    [ObservableProperty] private string databaseName = "website-content";
+    [ObservableProperty] private bool isConnected;
+    [ObservableProperty] private string statusMessage = "Not connected";
+    [ObservableProperty] private bool isBusy;
+
+    // ── Movies ──
+    [ObservableProperty] private ObservableCollection<MovieDocument> movies = [];
+    [ObservableProperty] private MovieDocument? selectedMovie;
+    [ObservableProperty] private ObservableCollection<string> movieCategories = [];
+    [ObservableProperty] private string? selectedMovieCategory;
+
+    // ── Series ──
+    [ObservableProperty] private ObservableCollection<SeriesDocument> series = [];
+    [ObservableProperty] private SeriesDocument? selectedSeries;
+    [ObservableProperty] private ObservableCollection<string> seriesCategories = [];
+    [ObservableProperty] private string? selectedSeriesCategory;
+
+    // ── Gaming ──
+    [ObservableProperty] private ObservableCollection<GamingDocument> gamingItems = [];
+    [ObservableProperty] private GamingDocument? selectedGaming;
+    [ObservableProperty] private ObservableCollection<string> gamingPlatforms = [];
+    [ObservableProperty] private string? selectedGamingPlatform;
+
+    // ── Parks ──
+    [ObservableProperty] private ObservableCollection<ParkDocument> parks = [];
+    [ObservableProperty] private ParkDocument? selectedPark;
+    [ObservableProperty] private ObservableCollection<string> parkProviders = [];
+    [ObservableProperty] private string? selectedParkProvider;
+
+    // ── Monthly Updates ──
+    [ObservableProperty] private ObservableCollection<MonthlyUpdateDocument> monthlyUpdates = [];
+    [ObservableProperty] private MonthlyUpdateDocument? selectedMonthlyUpdate;
+    [ObservableProperty] private ObservableCollection<string> monthlyUpdateMonths = [];
+    [ObservableProperty] private string? selectedMonth;
+
+    // ── JSON Editor ──
+    [ObservableProperty] private string jsonEditorContent = string.Empty;
+    [ObservableProperty] private bool isJsonEditorOpen;
+    [ObservableProperty] private string jsonEditorTitle = string.Empty;
+    private string? _jsonEditorContainer;
+    private string? _jsonEditorPartitionKey;
+    private bool _jsonEditorIsNew;
+
+    [RelayCommand]
+    private async Task ConnectAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Endpoint) || string.IsNullOrWhiteSpace(Key))
+        {
+            StatusMessage = "Please enter endpoint and key.";
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Connecting...";
+        try
+        {
+            _service?.Dispose();
+            _service = new CosmosManagerService(Endpoint, Key, DatabaseName);
+            await _service.TestConnectionAsync();
+            IsConnected = true;
+            StatusMessage = $"Connected to {DatabaseName}";
+            await LoadFiltersAsync();
+        }
+        catch (Exception ex)
+        {
+            IsConnected = false;
+            StatusMessage = $"Connection failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Disconnect()
+    {
+        _service?.Dispose();
+        _service = null;
+        IsConnected = false;
+        StatusMessage = "Disconnected";
+        ClearAll();
+    }
+
+    private void ClearAll()
+    {
+        Movies.Clear(); Series.Clear(); GamingItems.Clear(); Parks.Clear(); MonthlyUpdates.Clear();
+        MovieCategories.Clear(); SeriesCategories.Clear(); GamingPlatforms.Clear();
+        ParkProviders.Clear(); MonthlyUpdateMonths.Clear();
+    }
+
+    private async Task LoadFiltersAsync()
+    {
+        if (_service == null) return;
+        try
+        {
+            var movieCats = await _service.GetDistinctValuesAsync(CosmosManagerService.MoviesContainer, "category");
+            MovieCategories = new ObservableCollection<string>(movieCats);
+
+            var seriesCats = await _service.GetDistinctValuesAsync(CosmosManagerService.SeriesContainer, "category");
+            SeriesCategories = new ObservableCollection<string>(seriesCats);
+
+            var platforms = await _service.GetDistinctValuesAsync(CosmosManagerService.GamingContainer, "platform");
+            GamingPlatforms = new ObservableCollection<string>(platforms);
+
+            var providers = await _service.GetDistinctValuesAsync(CosmosManagerService.ParksContainer, "provider");
+            ParkProviders = new ObservableCollection<string>(providers);
+
+            var months = await _service.GetDistinctValuesAsync(CosmosManagerService.MonthlyUpdatesContainer, "month");
+            MonthlyUpdateMonths = new ObservableCollection<string>(months.OrderByDescending(m => m));
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error loading filters: {ex.Message}";
+        }
+    }
+
+    // ── Movies CRUD ──
+
+    [RelayCommand]
+    private async Task LoadMoviesAsync()
+    {
+        if (_service == null) return;
+        IsBusy = true;
+        try
+        {
+            var items = await _service.GetAllAsync<MovieDocument>(
+                CosmosManagerService.MoviesContainer, SelectedMovieCategory, "category");
+            Movies = new ObservableCollection<MovieDocument>(items);
+            StatusMessage = $"Loaded {items.Count} movies";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void NewMovie()
+    {
+        var json = JsonSerializer.Serialize(new MovieDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            Category = SelectedMovieCategory ?? "watched"
+        }, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        OpenJsonEditor("New Movie", CosmosManagerService.MoviesContainer, SelectedMovieCategory ?? "watched", json, isNew: true);
+    }
+
+    [RelayCommand]
+    private async Task EditMovieAsync()
+    {
+        if (_service == null || SelectedMovie == null) return;
+        IsBusy = true;
+        try
+        {
+            var json = await _service.GetItemJsonAsync(CosmosManagerService.MoviesContainer, SelectedMovie.Id, SelectedMovie.Category);
+            OpenJsonEditor($"Edit Movie: {SelectedMovie.TitleId}", CosmosManagerService.MoviesContainer, SelectedMovie.Category, json, isNew: false);
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task DeleteMovieAsync()
+    {
+        if (_service == null || SelectedMovie == null) return;
+        if (MessageBox.Show($"Delete movie '{SelectedMovie.TitleId}'?", "Confirm Delete", MessageBoxButton.YesNo) != MessageBoxResult.Yes) return;
+        IsBusy = true;
+        try
+        {
+            await _service.DeleteAsync(CosmosManagerService.MoviesContainer, SelectedMovie.Id, SelectedMovie.Category);
+            Movies.Remove(SelectedMovie);
+            StatusMessage = "Movie deleted";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    // ── Series CRUD ──
+
+    [RelayCommand]
+    private async Task LoadSeriesAsync()
+    {
+        if (_service == null) return;
+        IsBusy = true;
+        try
+        {
+            var items = await _service.GetAllAsync<SeriesDocument>(
+                CosmosManagerService.SeriesContainer, SelectedSeriesCategory, "category");
+            Series = new ObservableCollection<SeriesDocument>(items);
+            StatusMessage = $"Loaded {items.Count} series";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void NewSeries()
+    {
+        var json = JsonSerializer.Serialize(new SeriesDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            Category = SelectedSeriesCategory ?? "watched"
+        }, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        OpenJsonEditor("New Series", CosmosManagerService.SeriesContainer, SelectedSeriesCategory ?? "watched", json, isNew: true);
+    }
+
+    [RelayCommand]
+    private async Task EditSeriesAsync()
+    {
+        if (_service == null || SelectedSeries == null) return;
+        IsBusy = true;
+        try
+        {
+            var json = await _service.GetItemJsonAsync(CosmosManagerService.SeriesContainer, SelectedSeries.Id, SelectedSeries.Category);
+            OpenJsonEditor($"Edit Series: {SelectedSeries.TitleId}", CosmosManagerService.SeriesContainer, SelectedSeries.Category, json, isNew: false);
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task DeleteSeriesAsync()
+    {
+        if (_service == null || SelectedSeries == null) return;
+        if (MessageBox.Show($"Delete series '{SelectedSeries.TitleId}'?", "Confirm Delete", MessageBoxButton.YesNo) != MessageBoxResult.Yes) return;
+        IsBusy = true;
+        try
+        {
+            await _service.DeleteAsync(CosmosManagerService.SeriesContainer, SelectedSeries.Id, SelectedSeries.Category);
+            Series.Remove(SelectedSeries);
+            StatusMessage = "Series deleted";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    // ── Gaming CRUD ──
+
+    [RelayCommand]
+    private async Task LoadGamingAsync()
+    {
+        if (_service == null || string.IsNullOrEmpty(SelectedGamingPlatform)) return;
+        IsBusy = true;
+        try
+        {
+            var items = await _service.GetAllAsync<GamingDocument>(
+                CosmosManagerService.GamingContainer, SelectedGamingPlatform, "platform");
+            GamingItems = new ObservableCollection<GamingDocument>(items.OrderBy(g => g.Order));
+            StatusMessage = $"Loaded {items.Count} gaming items for {SelectedGamingPlatform}";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void NewGaming()
+    {
+        var json = JsonSerializer.Serialize(new GamingDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            Platform = SelectedGamingPlatform ?? "xbox"
+        }, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        OpenJsonEditor("New Gaming Entry", CosmosManagerService.GamingContainer, SelectedGamingPlatform ?? "xbox", json, isNew: true);
+    }
+
+    [RelayCommand]
+    private async Task EditGamingAsync()
+    {
+        if (_service == null || SelectedGaming == null) return;
+        IsBusy = true;
+        try
+        {
+            var json = await _service.GetItemJsonAsync(CosmosManagerService.GamingContainer, SelectedGaming.Id, SelectedGaming.Platform);
+            OpenJsonEditor($"Edit Gaming: {SelectedGaming.Title}", CosmosManagerService.GamingContainer, SelectedGaming.Platform, json, isNew: false);
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task DeleteGamingAsync()
+    {
+        if (_service == null || SelectedGaming == null) return;
+        if (MessageBox.Show($"Delete gaming entry '{SelectedGaming.Title}'?", "Confirm Delete", MessageBoxButton.YesNo) != MessageBoxResult.Yes) return;
+        IsBusy = true;
+        try
+        {
+            await _service.DeleteAsync(CosmosManagerService.GamingContainer, SelectedGaming.Id, SelectedGaming.Platform);
+            GamingItems.Remove(SelectedGaming);
+            StatusMessage = "Gaming entry deleted";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    // ── Parks CRUD ──
+
+    [RelayCommand]
+    private async Task LoadParksAsync()
+    {
+        if (_service == null || string.IsNullOrEmpty(SelectedParkProvider)) return;
+        IsBusy = true;
+        try
+        {
+            var items = await _service.GetAllAsync<ParkDocument>(
+                CosmosManagerService.ParksContainer, SelectedParkProvider, "provider");
+            Parks = new ObservableCollection<ParkDocument>(items);
+            StatusMessage = $"Loaded {items.Count} parks for {SelectedParkProvider}";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void NewPark()
+    {
+        var json = JsonSerializer.Serialize(new ParkDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            Provider = SelectedParkProvider ?? "disney"
+        }, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        OpenJsonEditor("New Park", CosmosManagerService.ParksContainer, SelectedParkProvider ?? "disney", json, isNew: true);
+    }
+
+    [RelayCommand]
+    private async Task EditParkAsync()
+    {
+        if (_service == null || SelectedPark == null) return;
+        IsBusy = true;
+        try
+        {
+            var json = await _service.GetItemJsonAsync(CosmosManagerService.ParksContainer, SelectedPark.Id, SelectedPark.Provider);
+            OpenJsonEditor($"Edit Park: {SelectedPark.Name?.En ?? SelectedPark.ParkId}", CosmosManagerService.ParksContainer, SelectedPark.Provider, json, isNew: false);
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task DeleteParkAsync()
+    {
+        if (_service == null || SelectedPark == null) return;
+        if (MessageBox.Show($"Delete park '{SelectedPark.Name?.En ?? SelectedPark.ParkId}'?", "Confirm Delete", MessageBoxButton.YesNo) != MessageBoxResult.Yes) return;
+        IsBusy = true;
+        try
+        {
+            await _service.DeleteAsync(CosmosManagerService.ParksContainer, SelectedPark.Id, SelectedPark.Provider);
+            Parks.Remove(SelectedPark);
+            StatusMessage = "Park deleted";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    // ── Monthly Updates CRUD ──
+
+    [RelayCommand]
+    private async Task LoadMonthlyUpdatesAsync()
+    {
+        if (_service == null || string.IsNullOrEmpty(SelectedMonth)) return;
+        IsBusy = true;
+        try
+        {
+            var items = await _service.GetAllAsync<MonthlyUpdateDocument>(
+                CosmosManagerService.MonthlyUpdatesContainer, SelectedMonth, "month");
+            MonthlyUpdates = new ObservableCollection<MonthlyUpdateDocument>(items.OrderBy(m => m.Order));
+            StatusMessage = $"Loaded {items.Count} monthly updates for {SelectedMonth}";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void NewMonthlyUpdate()
+    {
+        var json = JsonSerializer.Serialize(new MonthlyUpdateDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            Month = SelectedMonth ?? DateTime.Now.ToString("yyyy-MM")
+        }, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        OpenJsonEditor("New Monthly Update", CosmosManagerService.MonthlyUpdatesContainer, SelectedMonth ?? DateTime.Now.ToString("yyyy-MM"), json, isNew: true);
+    }
+
+    [RelayCommand]
+    private async Task EditMonthlyUpdateAsync()
+    {
+        if (_service == null || SelectedMonthlyUpdate == null) return;
+        IsBusy = true;
+        try
+        {
+            var json = await _service.GetItemJsonAsync(CosmosManagerService.MonthlyUpdatesContainer, SelectedMonthlyUpdate.Id, SelectedMonthlyUpdate.Month);
+            OpenJsonEditor($"Edit Monthly Update: {SelectedMonthlyUpdate.Title}", CosmosManagerService.MonthlyUpdatesContainer, SelectedMonthlyUpdate.Month, json, isNew: false);
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task DeleteMonthlyUpdateAsync()
+    {
+        if (_service == null || SelectedMonthlyUpdate == null) return;
+        if (MessageBox.Show($"Delete monthly update '{SelectedMonthlyUpdate.Title}'?", "Confirm Delete", MessageBoxButton.YesNo) != MessageBoxResult.Yes) return;
+        IsBusy = true;
+        try
+        {
+            await _service.DeleteAsync(CosmosManagerService.MonthlyUpdatesContainer, SelectedMonthlyUpdate.Id, SelectedMonthlyUpdate.Month);
+            MonthlyUpdates.Remove(SelectedMonthlyUpdate);
+            StatusMessage = "Monthly update deleted";
+        }
+        catch (Exception ex) { StatusMessage = $"Error: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    // ── JSON Editor ──
+
+    private void OpenJsonEditor(string title, string container, string partitionKey, string json, bool isNew)
+    {
+        JsonEditorTitle = title;
+        _jsonEditorContainer = container;
+        _jsonEditorPartitionKey = partitionKey;
+        _jsonEditorIsNew = isNew;
+        JsonEditorContent = json;
+        IsJsonEditorOpen = true;
+    }
+
+    [RelayCommand]
+    private async Task SaveJsonAsync()
+    {
+        if (_service == null || _jsonEditorContainer == null || _jsonEditorPartitionKey == null) return;
+        IsBusy = true;
+        try
+        {
+            // Validate JSON
+            JsonDocument.Parse(JsonEditorContent);
+
+            if (_jsonEditorIsNew)
+                await _service.CreateItemFromJsonAsync(_jsonEditorContainer, JsonEditorContent, _jsonEditorPartitionKey);
+            else
+                await _service.SaveItemJsonAsync(_jsonEditorContainer, JsonEditorContent, _jsonEditorPartitionKey);
+
+            IsJsonEditorOpen = false;
+            StatusMessage = _jsonEditorIsNew ? "Item created successfully" : "Item saved successfully";
+
+            // Reload the current section
+            await ReloadCurrentSectionAsync();
+        }
+        catch (JsonException)
+        {
+            StatusMessage = "Invalid JSON. Please fix the syntax and try again.";
+        }
+        catch (Exception ex) { StatusMessage = $"Error saving: {ex.Message}"; }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private void CancelJsonEditor()
+    {
+        IsJsonEditorOpen = false;
+    }
+
+    private async Task ReloadCurrentSectionAsync()
+    {
+        switch (_jsonEditorContainer)
+        {
+            case CosmosManagerService.MoviesContainer: await LoadMoviesAsync(); break;
+            case CosmosManagerService.SeriesContainer: await LoadSeriesAsync(); break;
+            case CosmosManagerService.GamingContainer: await LoadGamingAsync(); break;
+            case CosmosManagerService.ParksContainer: await LoadParksAsync(); break;
+            case CosmosManagerService.MonthlyUpdatesContainer: await LoadMonthlyUpdatesAsync(); break;
+        }
+    }
+}

--- a/website.sln
+++ b/website.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api", "api\api.csproj", "{C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api.tests", "api.tests\api.tests.csproj", "{9CE1789F-CD4E-4513-9965-157434FE043D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cosmos-manager", "cosmos-manager", "{80155EE3-25B5-C622-722E-6B827847FB1E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosManager", "cosmos-manager\CosmosManager.csproj", "{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,9 +45,24 @@ Global
 		{9CE1789F-CD4E-4513-9965-157434FE043D}.Release|x64.Build.0 = Release|Any CPU
 		{9CE1789F-CD4E-4513-9965-157434FE043D}.Release|x86.ActiveCfg = Release|Any CPU
 		{9CE1789F-CD4E-4513-9965-157434FE043D}.Release|x86.Build.0 = Release|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Debug|x64.Build.0 = Debug|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Debug|x86.Build.0 = Debug|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Release|x64.ActiveCfg = Release|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Release|x64.Build.0 = Release|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Release|x86.ActiveCfg = Release|Any CPU
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9628E4E3-AF26-485A-8777-C9BA0FF3B1FF} = {80155EE3-25B5-C622-722E-6B827847FB1E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {662184C8-749B-4DB2-9488-429A44D76B0F}


### PR DESCRIPTION
Introduce a new WPF application (cosmos-manager) to manage website content stored in Cosmos DB. Added UI (MainWindow.xaml, App.xaml), MVVM MainViewModel, models for content types (movies, series, gaming, parks, monthly updates), JSON-localized text model, value converters, and a CosmosManagerService that wraps Cosmos DB CRUD, queries and raw JSON editing. Project file includes CommunityToolkit.Mvvm, Microsoft.Azure.Cosmos and Newtonsoft.Json. Also updated solution to include the new project.