### PR TITLE
Add Cosmos Manager CI and update workflows

### DIFF
--- a/.github/workflows/azure-static-web-app.yml
+++ b/.github/workflows/azure-static-web-app.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/dependency-review.yml'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'cosmos-manager/**'
       - 'LICENSE'
   pull_request:
     types: [opened, synchronize, reopened, closed]
@@ -19,6 +20,7 @@ on:
       - '.github/workflows/dependency-review.yml'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'cosmos-manager/**'
       - 'LICENSE'
   workflow_dispatch:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,12 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'cosmos-manager/**'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'cosmos-manager/**'
   workflow_dispatch:
 jobs:
   analyze:
@@ -26,12 +30,15 @@ jobs:
       with:
         languages: ${{ matrix.language }}
     - name: Setup .NET
+      if: matrix.language == 'csharp'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '9.0.x'
-    - name: Restore .NET
-      run: dotnet restore
+    - name: Build .NET API
+      if: matrix.language == 'csharp'
+      run: dotnet build api/api.csproj --configuration Release
     - name: Autobuild
+      if: matrix.language != 'csharp'
       uses: github/codeql-action/autobuild@v3
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/cosmos-manager.yml
+++ b/.github/workflows/cosmos-manager.yml
@@ -1,0 +1,47 @@
+name: Build Cosmos Manager (WPF)
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'cosmos-manager/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'cosmos-manager/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: windows-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore Dependencies
+        run: dotnet restore
+        working-directory: cosmos-manager
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        working-directory: cosmos-manager
+
+      - name: Publish
+        run: dotnet publish --configuration Release --no-build --output ./publish
+        working-directory: cosmos-manager
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosmos-manager
+          path: cosmos-manager/publish/
+          retention-days: 14

--- a/.github/workflows/cosmos-manager.yml
+++ b/.github/workflows/cosmos-manager.yml
@@ -13,10 +13,11 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build:
-    name: Build & Test
+    name: Build
     runs-on: windows-latest
     steps:
       - name: Check Out Repo

--- a/cosmos-manager/App.xaml.cs
+++ b/cosmos-manager/App.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Configuration;
-using System.Data;
-using System.Windows;
+﻿using System.Windows;
 
 namespace CosmosManager;
 

--- a/cosmos-manager/CosmosManager.csproj
+++ b/cosmos-manager/CosmosManager.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <!-- Allow dotnet restore on non-Windows CI (e.g., GitHub dependency graph submission) -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cosmos-manager/Services/CosmosManagerService.cs
+++ b/cosmos-manager/Services/CosmosManagerService.cs
@@ -93,6 +93,8 @@ public class CosmosManagerService : IDisposable
     {
         var container = GetContainer(containerName);
         var response = await container.ReadItemStreamAsync(id, new PartitionKey(partitionKeyValue));
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Failed to read item '{id}' from '{containerName}': {response.StatusCode}");
         using var reader = new StreamReader(response.Content);
         var raw = await reader.ReadToEndAsync();
         // Re-format with indentation

--- a/cosmos-manager/ViewModels/MainViewModel.cs
+++ b/cosmos-manager/ViewModels/MainViewModel.cs
@@ -428,6 +428,16 @@ public partial class MainViewModel : ObservableObject
 
     // ── JSON Editor ──
 
+    private static string? GetPartitionKeyField(string? containerName) => containerName switch
+    {
+        CosmosManagerService.MoviesContainer => "category",
+        CosmosManagerService.SeriesContainer => "category",
+        CosmosManagerService.GamingContainer => "platform",
+        CosmosManagerService.ParksContainer => "provider",
+        CosmosManagerService.MonthlyUpdatesContainer => "month",
+        _ => null
+    };
+
     private void OpenJsonEditor(string title, string container, string partitionKey, string json, bool isNew)
     {
         JsonEditorTitle = title;
@@ -445,8 +455,13 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            // Validate JSON
-            JsonDocument.Parse(JsonEditorContent);
+            // Validate JSON and extract partition key from edited content
+            using var validationDoc = JsonDocument.Parse(JsonEditorContent);
+            var pkField = GetPartitionKeyField(_jsonEditorContainer);
+            if (pkField != null && validationDoc.RootElement.TryGetProperty(pkField, out var pkElement))
+            {
+                _jsonEditorPartitionKey = pkElement.GetString() ?? _jsonEditorPartitionKey;
+            }
 
             if (_jsonEditorIsNew)
                 await _service.CreateItemFromJsonAsync(_jsonEditorContainer, JsonEditorContent, _jsonEditorPartitionKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12731,9 +12731,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "vitest": "^4.1.4"
   },
   "overrides": {
+    "dompurify": "^3.4.0",
     "lodash-es": "4.18.1",
     "axios": "^1.15.0",
     "serialize-javascript": "7.0.5",


### PR DESCRIPTION
Add a new GitHub Actions workflow to build/publish the Cosmos Manager WPF app (cosmos-manager.yml) which runs on windows-latest, sets up .NET 9, restores, builds, publishes and uploads the publish artifact. Update azure-static-web-app.yml to include 'cosmos-manager/**' in the watched paths for push and pull_request. Update codeql.yml to ignore the cosmos-manager path for push and pull_request and to conditionally handle C# builds: setup-dotnet and run a dotnet build for the C# matrix entry, while using the autobuild step for non-C# languages. These changes isolate the WPF build into its own CI flow and prevent CodeQL from running against the platform-specific project.