### PR TITLE
Add blog on agentic workflow governance

### DIFF
--- a/blog/2026-04-17-SecurityComplianceAgenticWorkflows.mdx
+++ b/blog/2026-04-17-SecurityComplianceAgenticWorkflows.mdx
@@ -1,0 +1,137 @@
+---
+title: "Security and compliance in agentic workflows: the governance layer teams are missing"
+description: "As AI agents write code, open pull requests, and trigger deployments, the security model built for human accountability breaks down. Teams need to answer three governance questions before they can safely scale agentic workflows: audit, accountability, and control."
+slug: security-compliance-agentic-workflows
+authors: [dsanchezcr]
+tags: [Security, DevSecOps, Agentic AI, GitHub Advanced Security, GitHub Copilot, Microsoft Defender for Cloud, Governance]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-17-security-compliance-agentic/security-compliance-agentic.jpg
+date: 2026-04-17T10:00
+---
+
+# Security and compliance in agentic workflows: the governance layer teams are missing
+
+Picture this. A [GitHub Copilot coding agent](https://github.com/features/copilot/agents) picks up an issue, creates a branch, writes the implementation across four files, adds tests, and opens a pull request. CI passes. Code scanning reports no alerts. A developer reviews the diff, approves, and merges. The change ships to production through an automated deployment pipeline.
+
+Three weeks later, a penetration test discovers that the agent-generated code introduced a server-side request forgery vulnerability. The code was syntactically clean, the tests covered the happy path, and the reviewer did not catch the flaw because the logic looked reasonable in isolation. Now the team needs to answer a question that their security model was never designed for: who is accountable for code that no human wrote?
+
+{/* truncate */}
+
+![Security and compliance in agentic workflows](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-17-security-compliance-agentic/security-compliance-agentic.jpg)
+
+That question is not hypothetical. It is the governance gap that most engineering organizations have not addressed, even as they adopt agentic tools at an accelerating pace. In my earlier posts on [rolling out GitHub Advanced Security at scale](/blog/ghas-rollout) and [building CI/CD pipelines for the agentic era](/blog/cicd-pipelines-agentic-era), I focused on detection and verification. This post goes deeper into the governance layer that sits underneath both: how do you audit what agents did, who owns the output, and how do you enforce boundaries on agent behavior before something goes wrong?
+
+---
+
+## The security model was built for humans
+
+Every security control in a modern software delivery pipeline assumes a human is behind the keyboard. Branch protection rules exist because humans might push directly to main. Required reviewers exist because humans make mistakes that other humans can catch. Code scanning flags vulnerabilities because humans might introduce them without realizing it. Secret scanning catches credentials because humans might copy a connection string into source code.
+
+These controls work because they are calibrated to human behavior. Humans write code with intent. They understand the business context of what they are building. When a reviewer approves a pull request, the implicit contract is that another thinking person has evaluated the change and accepted responsibility for it.
+
+Agents break that contract in subtle but important ways. An agent does not have intent in the way a human does. It generates code that satisfies a prompt, not code that reflects an understanding of the system's threat model. When an agent introduces a dependency, it does not evaluate the maintainer's reputation or the package's security history. When it writes an API endpoint, it does not consider whether the endpoint could be abused in combination with other endpoints in the system.
+
+The existing tools still catch many of the resulting problems. [GitHub Advanced Security](https://github.com/enterprise/advanced-security) will flag a known vulnerability in an agent-added dependency. [Code scanning with CodeQL](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) will detect common vulnerability patterns in agent-generated code. But detection is only one layer of security. Governance requires answering harder questions about accountability, traceability, and control, questions that the human-centric model never needed to ask because the answers were implicit.
+
+---
+
+## Three governance questions every team needs to answer
+
+When agents become active contributors to a codebase, three questions move from theoretical to urgent. Teams that do not answer them explicitly will answer them by default, usually after an incident, and usually with an answer they do not like.
+
+### 1. Audit: what did the agent do and why?
+
+Traceability is the foundation of governance. If you cannot reconstruct what an agent did, which files it modified, which prompts it received, which decisions it made, you cannot investigate incidents, satisfy compliance requirements, or improve your controls.
+
+The good news is that much of this infrastructure already exists. Git preserves a complete history of every change. GitHub Actions produces audit logs for every workflow run. [GitHub's audit log API](https://docs.github.com/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/about-the-audit-log-for-your-enterprise) captures who triggered what, when, and from where. OIDC tokens in GitHub Actions tie workflow runs to verifiable identities, making it possible to distinguish between a deployment triggered by a human and one triggered by an automated process.
+
+The challenge is that these signals are scattered. A single agent-authored PR might span a Git commit history, a GitHub Actions workflow log, a code scanning result, a dependency review output, and an approval event. Reconstructing the full picture requires correlating across these sources. Teams that are serious about governance should establish retention policies for audit logs, build dashboards that surface agent activity as a distinct category, and ensure that every agent-authored commit carries metadata that links it back to the task assignment and the human who authorized it.
+
+This is not a new problem, but agentic workflows make it more urgent. When a human writes code, you can ask them what they were thinking. When an agent writes code, the audit trail is the only witness.
+
+### 2. Accountability: who owns agent-generated code?
+
+Accountability in software has always been distributed. The developer who writes the code, the reviewer who approves it, the team lead who prioritizes the work, and the organization that ships the product all share responsibility. Agent-generated code does not eliminate any of these roles. It adds a new participant whose responsibilities are undefined.
+
+The practical answer, for now, is that the human who delegates work to an agent owns the output. If you assign a GitHub issue to Copilot coding agent and it opens a pull request, you are the accountable party. You chose to delegate, and you are responsible for verifying the result. The reviewer who approves the PR shares that responsibility, just as they would with any other contributor's code.
+
+But this model strains under scale. If a single engineer delegates twenty tasks to agents in a day and reviews twenty resulting pull requests, the depth of each review inevitably decreases. The accountability surface expands while the attention budget stays fixed. Engineering leaders need to recognize this tension and set realistic expectations for how many agent-authored PRs a single developer should be expected to review in a given period.
+
+Organizations should also make accountability explicit in their development policies. If your team does not have a written statement about who owns agent-generated code, write one. If your review policy does not distinguish between agent-authored and human-authored pull requests, update it. Ambiguity in accountability is a liability that grows with every agent-authored commit that reaches production.
+
+### 3. Control: how do you govern agent permissions and scope?
+
+The most actionable governance question is also the most overlooked: what is the agent allowed to do?
+
+GitHub Copilot coding agent operates within the permissions granted to it. It can only access repositories it has been given access to, and it can only perform actions that its integration allows. But "can access the repository" is a broad permission. An agent assigned to fix a CSS bug does not need the ability to modify GitHub Actions workflows, infrastructure templates, or API endpoint code. Without scoping, the agent operates with the full set of permissions it was granted, not the minimum set required for the task.
+
+[GitHub Rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) provide one mechanism for control. You can define rules that restrict which branches can receive commits, require specific status checks to pass before merging, and enforce review requirements. These rules apply equally to human and agent contributors, which means they provide a baseline of control that does not depend on the agent's own behavior.
+
+Beyond rulesets, teams should implement policy-as-code patterns that validate agent output against organizational standards. This can be as straightforward as a GitHub Actions workflow step that checks whether an agent-authored PR modifies files outside a predefined scope, introduces new dependencies without approval, or touches security-sensitive paths like workflow files or infrastructure definitions. My [CI/CD pipelines for the agentic era](/blog/cicd-pipelines-agentic-era) post covers specific implementation patterns for these checks.
+
+The principle is least privilege, applied not just to infrastructure access but to repository scope. Agents should have the narrowest permissions that allow them to complete their assigned tasks, and those permissions should be enforced by the platform, not by the agent's own restraint.
+
+---
+
+## Practical tooling: detection, traceability, and posture
+
+Governance is not a single tool. It is a stack. Each layer addresses a different aspect of the problem, and the layers reinforce each other.
+
+### Detection: GitHub Advanced Security
+
+[GitHub Advanced Security](https://github.com/enterprise/advanced-security) remains the primary detection layer for vulnerabilities in agent-generated code. The same capabilities I described in my [GHAS rollout post](/blog/ghas-rollout) apply here, with one important extension: when agents are generating code, the volume of changes that need scanning increases, and the types of vulnerabilities shift.
+
+[Secret scanning](https://docs.github.com/code-security/secret-scanning/introduction/about-secret-scanning) catches credentials that agents might embed in code. This matters more in agentic workflows because agents do not have the same instinct a human developer has to avoid committing secrets. If an agent is working from a prompt that includes a connection string as context, it may reproduce that string in the generated code.
+
+[Code scanning with CodeQL](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) identifies vulnerability patterns in the generated code itself: SQL injection, cross-site scripting, path traversal, and other categories from the OWASP Top 10. CodeQL's strength is that it analyzes data flow, not just syntax, which means it can catch vulnerabilities that look correct on the surface but create exploitable paths through the application.
+
+[Dependency review](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review) evaluates new dependencies that agents introduce. Agents frequently add packages to solve problems, sometimes packages that are unmaintained, have known vulnerabilities, or duplicate functionality that already exists in the project. Dependency review surfaces these risks before the PR merges, giving reviewers a concrete signal to act on.
+
+These tools do not require any special configuration for agent-generated code. They apply the same analysis regardless of who authored the change. That uniformity is a strength: agents are held to the same security standard as humans, automatically.
+
+### Traceability: audit logs and OIDC
+
+GitHub's [audit log](https://docs.github.com/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/about-the-audit-log-for-your-enterprise) records organizational activity at a granular level: repository access, permission changes, workflow triggers, and more. For agentic governance, the audit log provides the raw material for answering "what happened" after an incident.
+
+[OIDC tokens in GitHub Actions](https://docs.github.com/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) add a second dimension of traceability. When a workflow requests a token from a cloud provider, the token includes claims that identify the repository, branch, workflow, and triggering actor. This means that a deployment triggered by an agent-authored merge can be traced from the cloud resource back to the specific workflow run, the specific PR, and the specific commit, creating an end-to-end chain of custody.
+
+Teams should ensure that their OIDC subject claims are granular enough to distinguish between human-triggered and agent-triggered deployments. A subject claim that includes the actor identity (for example, `repo:org/repo:ref:refs/heads/main:actor:copilot-agent`) makes it possible to filter and audit agent-initiated deployments separately from human-initiated ones.
+
+### Runtime posture: Microsoft Defender for Cloud
+
+Detection and traceability address the pipeline. [Microsoft Defender for Cloud](https://azure.microsoft.com/products/defender-for-cloud) extends governance into the runtime environment, where agent-generated code actually executes.
+
+Defender for Cloud's DevOps security connector imports findings from GitHub Advanced Security into a centralized dashboard, providing a single view of security posture across repositories and cloud resources. This is particularly valuable when agents are generating code across multiple repositories, because it consolidates the risk picture that would otherwise be fragmented across individual repository security tabs.
+
+The runtime protection layer monitors deployed workloads for anomalous behavior: unexpected network connections, privilege escalation attempts, and container image vulnerabilities. If agent-generated code introduces a subtle vulnerability that passes code scanning but manifests as anomalous behavior in production, Defender for Cloud provides the signal that closes the gap.
+
+As I discussed in the [GHAS rollout post](/blog/ghas-rollout), integrating Defender for Cloud with GitHub Advanced Security creates a feedback loop: vulnerabilities detected in production can be traced back to the code change that introduced them, and that trace can inform better prompts, tighter agent scoping, or additional CodeQL queries.
+
+---
+
+## What engineering leaders should put in place now
+
+Governance frameworks take time to mature. But there are concrete steps that engineering leaders can implement today, before agentic workflows reach a scale where governance gaps become incidents.
+
+**Agent-scoped permissions.** Apply the principle of least privilege to every agent integration. If an agent only needs to modify application code, do not give it access to infrastructure templates or workflow files. Review the permissions granted to Copilot coding agent and other integrations, and narrow them to match actual use cases.
+
+**Required human review gates.** Every agent-authored pull request should require human approval before merging. This is not a new concept. It is the same branch protection rule that already exists. But it should be an explicit policy, not an assumption. Consider requiring a higher number of reviewers for agent-authored PRs, or requiring reviewers with specific domain expertise.
+
+**Audit log retention.** GitHub audit logs have configurable retention periods. Set them to match your organization's compliance requirements, and ensure that agent activity is captured with enough detail to support incident investigations. If your retention period is 90 days and your security review cycle is quarterly, you may be deleting evidence before it is reviewed.
+
+**Policy-as-code with GitHub Rulesets.** Define and enforce repository rules that apply to all contributors, including agents. Use [rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) to require status checks, restrict file path modifications, and enforce branch naming conventions. These rules are version-controlled and auditable, which means they satisfy compliance requirements that manual configuration does not.
+
+**Agent activity dashboards.** Build visibility into how agents are being used across your organization. Track metrics like the number of agent-authored PRs per week, the percentage that require revision after human review, and the types of security findings in agent-generated code. These metrics inform policy decisions and help calibrate expectations for review workload.
+
+---
+
+## Governance is not a brake, it is a foundation
+
+There is a temptation to treat governance as the thing that slows you down. Every required review, every audit log query, every permission restriction feels like friction against the speed that agents promise.
+
+That framing is backward. The teams that will scale agentic workflows successfully are the ones that build the governance layer first, not the ones that move fast and retrofit controls after an incident. Speed without traceability is recklessness. Autonomy without accountability is risk. Delegation without control is abdication.
+
+AI agents do not reduce the need for security discipline. They raise the standard. When a significant portion of your codebase is written by non-human contributors, the rigor of your security controls, the completeness of your audit trails, and the clarity of your accountability model become the differentiators between organizations that ship with confidence and organizations that ship with anxiety.
+
+The security model built for human developers was a good foundation. It is not sufficient for what comes next. The governance layer that sits on top of it, covering audit, accountability, and control, is what teams need to build now, before the gap becomes a headline.

--- a/i18n/es/docusaurus-plugin-content-blog/2026-04-17-SecurityComplianceAgenticWorkflows.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-04-17-SecurityComplianceAgenticWorkflows.mdx
@@ -1,0 +1,137 @@
+---
+title: "Seguridad y cumplimiento en flujos de trabajo agénticos: la capa de gobernanza que los equipos están pasando por alto"
+description: "A medida que los agentes de IA escriben código, abren pull requests y activan despliegues, el modelo de seguridad construido para la responsabilidad humana se desmorona. Los equipos necesitan responder tres preguntas de gobernanza antes de poder escalar los flujos de trabajo agénticos de forma segura: auditoría, responsabilidad y control."
+slug: security-compliance-agentic-workflows
+authors: [dsanchezcr]
+tags: [Security, DevSecOps, Agentic AI, GitHub Advanced Security, GitHub Copilot, Microsoft Defender for Cloud, Governance]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-17-security-compliance-agentic/security-compliance-agentic.jpg
+date: 2026-04-17T10:00
+---
+
+# Seguridad y cumplimiento en flujos de trabajo agénticos: la capa de gobernanza que los equipos están pasando por alto
+
+Imagina esto. Un [agente de codificación de GitHub Copilot](https://github.com/features/copilot/agents) toma un issue, crea una rama, escribe la implementación en cuatro archivos, agrega pruebas y abre un pull request. El CI pasa. El escaneo de código no reporta alertas. Un desarrollador revisa el diff, lo aprueba y hace merge. El cambio se despliega a producción a través de un pipeline de despliegue automatizado.
+
+Tres semanas después, una prueba de penetración descubre que el código generado por el agente introdujo una vulnerabilidad de falsificación de solicitudes del lado del servidor. El código era sintácticamente limpio, las pruebas cubrían el camino feliz, y el revisor no detectó la falla porque la lógica se veía razonable de forma aislada. Ahora el equipo necesita responder una pregunta para la cual su modelo de seguridad nunca fue diseñado: ¿quién es responsable del código que ningún humano escribió?
+
+{/* truncate */}
+
+![Seguridad y cumplimiento en flujos de trabajo agénticos](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-17-security-compliance-agentic/security-compliance-agentic.jpg)
+
+Esa pregunta no es hipotética. Es la brecha de gobernanza que la mayoría de las organizaciones de ingeniería no han abordado, incluso mientras adoptan herramientas agénticas a un ritmo acelerado. En mis publicaciones anteriores sobre [implementar GitHub Advanced Security a escala](/blog/ghas-rollout) y [construir pipelines de CI/CD para la era agéntica](/blog/cicd-pipelines-agentic-era), me enfoqué en detección y verificación. Esta publicación profundiza en la capa de gobernanza que se encuentra debajo de ambas: ¿cómo auditas lo que hicieron los agentes, quién es dueño del resultado y cómo impones límites al comportamiento del agente antes de que algo salga mal?
+
+---
+
+## El modelo de seguridad fue construido para humanos
+
+Cada control de seguridad en un pipeline moderno de entrega de software asume que hay un humano detrás del teclado. Las reglas de protección de ramas existen porque los humanos podrían hacer push directamente a main. Los revisores requeridos existen porque los humanos cometen errores que otros humanos pueden detectar. El escaneo de código señala vulnerabilidades porque los humanos podrían introducirlas sin darse cuenta. El escaneo de secretos detecta credenciales porque los humanos podrían copiar una cadena de conexión en el código fuente.
+
+Estos controles funcionan porque están calibrados para el comportamiento humano. Los humanos escriben código con intención. Entienden el contexto de negocio de lo que están construyendo. Cuando un revisor aprueba un pull request, el contrato implícito es que otra persona pensante ha evaluado el cambio y ha aceptado la responsabilidad por él.
+
+Los agentes rompen ese contrato de maneras sutiles pero importantes. Un agente no tiene intención de la manera que un humano la tiene. Genera código que satisface un prompt, no código que refleja una comprensión del modelo de amenazas del sistema. Cuando un agente introduce una dependencia, no evalúa la reputación del mantenedor ni el historial de seguridad del paquete. Cuando escribe un endpoint de API, no considera si el endpoint podría ser abusado en combinación con otros endpoints del sistema.
+
+Las herramientas existentes aún detectan muchos de los problemas resultantes. [GitHub Advanced Security](https://github.com/enterprise/advanced-security) señalará una vulnerabilidad conocida en una dependencia agregada por un agente. [El escaneo de código con CodeQL](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) detectará patrones de vulnerabilidad comunes en el código generado por agentes. Pero la detección es solo una capa de seguridad. La gobernanza requiere responder preguntas más difíciles sobre responsabilidad, trazabilidad y control, preguntas que el modelo centrado en humanos nunca necesitó hacer porque las respuestas eran implícitas.
+
+---
+
+## Tres preguntas de gobernanza que todo equipo necesita responder
+
+Cuando los agentes se convierten en contribuidores activos de un código base, tres preguntas pasan de teóricas a urgentes. Los equipos que no las respondan explícitamente las responderán por defecto, generalmente después de un incidente, y generalmente con una respuesta que no les gustará.
+
+### 1. Auditoría: ¿qué hizo el agente y por qué?
+
+La trazabilidad es el fundamento de la gobernanza. Si no puedes reconstruir lo que un agente hizo, qué archivos modificó, qué prompts recibió, qué decisiones tomó, no puedes investigar incidentes, cumplir con requisitos de cumplimiento ni mejorar tus controles.
+
+La buena noticia es que gran parte de esta infraestructura ya existe. Git preserva un historial completo de cada cambio. GitHub Actions produce logs de auditoría para cada ejecución de workflow. [La API de log de auditoría de GitHub](https://docs.github.com/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/about-the-audit-log-for-your-enterprise) captura quién activó qué, cuándo y desde dónde. Los tokens OIDC en GitHub Actions vinculan las ejecuciones de workflow a identidades verificables, haciendo posible distinguir entre un despliegue activado por un humano y uno activado por un proceso automatizado.
+
+El desafío es que estas señales están dispersas. Un solo PR creado por un agente podría abarcar un historial de commits de Git, un log de workflow de GitHub Actions, un resultado de escaneo de código, una salida de revisión de dependencias y un evento de aprobación. Reconstruir el panorama completo requiere correlacionar estas fuentes. Los equipos que toman en serio la gobernanza deberían establecer políticas de retención para los logs de auditoría, construir dashboards que muestren la actividad de los agentes como una categoría distinta, y asegurar que cada commit creado por un agente lleve metadatos que lo vinculen con la asignación de la tarea y el humano que la autorizó.
+
+Este no es un problema nuevo, pero los flujos de trabajo agénticos lo hacen más urgente. Cuando un humano escribe código, puedes preguntarle qué estaba pensando. Cuando un agente escribe código, el rastro de auditoría es el único testigo.
+
+### 2. Responsabilidad: ¿quién es dueño del código generado por agentes?
+
+La responsabilidad en el software siempre ha sido distribuida. El desarrollador que escribe el código, el revisor que lo aprueba, el líder del equipo que prioriza el trabajo y la organización que envía el producto comparten responsabilidad. El código generado por agentes no elimina ninguno de estos roles. Agrega un nuevo participante cuyas responsabilidades están indefinidas.
+
+La respuesta práctica, por ahora, es que el humano que delega trabajo a un agente es dueño del resultado. Si asignas un issue de GitHub al agente de codificación de Copilot y este abre un pull request, tú eres la parte responsable. Tú elegiste delegar, y eres responsable de verificar el resultado. El revisor que aprueba el PR comparte esa responsabilidad, tal como lo haría con el código de cualquier otro contribuidor.
+
+Pero este modelo se tensiona a escala. Si un solo ingeniero delega veinte tareas a agentes en un día y revisa veinte pull requests resultantes, la profundidad de cada revisión inevitablemente disminuye. La superficie de responsabilidad se expande mientras el presupuesto de atención permanece fijo. Los líderes de ingeniería necesitan reconocer esta tensión y establecer expectativas realistas sobre cuántos PRs creados por agentes un solo desarrollador debería revisar en un período determinado.
+
+Las organizaciones también deberían hacer explícita la responsabilidad en sus políticas de desarrollo. Si tu equipo no tiene una declaración escrita sobre quién es dueño del código generado por agentes, escríbela. Si tu política de revisión no distingue entre pull requests creados por agentes y los creados por humanos, actualízala. La ambigüedad en la responsabilidad es un pasivo que crece con cada commit generado por agentes que llega a producción.
+
+### 3. Control: ¿cómo gobiernas los permisos y el alcance del agente?
+
+La pregunta de gobernanza más accionable es también la más descuidada: ¿qué se le permite hacer al agente?
+
+El agente de codificación de GitHub Copilot opera dentro de los permisos que se le otorgan. Solo puede acceder a los repositorios a los que tiene acceso, y solo puede realizar acciones que su integración permite. Pero "puede acceder al repositorio" es un permiso amplio. Un agente asignado a corregir un bug de CSS no necesita la capacidad de modificar workflows de GitHub Actions, plantillas de infraestructura o código de endpoints de API. Sin delimitación, el agente opera con el conjunto completo de permisos que se le otorgaron, no con el conjunto mínimo requerido para la tarea.
+
+[GitHub Rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) proporcionan un mecanismo de control. Puedes definir reglas que restrinjan qué ramas pueden recibir commits, requerir que verificaciones de estado específicas pasen antes de hacer merge, e imponer requisitos de revisión. Estas reglas se aplican por igual a contribuidores humanos y agentes, lo que significa que proporcionan una línea base de control que no depende del comportamiento propio del agente.
+
+Más allá de los rulesets, los equipos deberían implementar patrones de política como código que validen la salida del agente contra los estándares organizacionales. Esto puede ser tan directo como un paso de workflow de GitHub Actions que verifique si un PR creado por un agente modifica archivos fuera de un alcance predefinido, introduce nuevas dependencias sin aprobación, o toca rutas sensibles a la seguridad como archivos de workflow o definiciones de infraestructura. Mi publicación sobre [pipelines de CI/CD para la era agéntica](/blog/cicd-pipelines-agentic-era) cubre patrones de implementación específicos para estas verificaciones.
+
+El principio es el de mínimo privilegio, aplicado no solo al acceso a infraestructura sino al alcance del repositorio. Los agentes deberían tener los permisos más estrechos que les permitan completar sus tareas asignadas, y esos permisos deberían ser impuestos por la plataforma, no por la moderación del propio agente.
+
+---
+
+## Herramientas prácticas: detección, trazabilidad y postura
+
+La gobernanza no es una sola herramienta. Es una pila. Cada capa aborda un aspecto diferente del problema, y las capas se refuerzan mutuamente.
+
+### Detección: GitHub Advanced Security
+
+[GitHub Advanced Security](https://github.com/enterprise/advanced-security) sigue siendo la capa principal de detección para vulnerabilidades en código generado por agentes. Las mismas capacidades que describí en mi [publicación sobre la implementación de GHAS](/blog/ghas-rollout) aplican aquí, con una extensión importante: cuando los agentes están generando código, el volumen de cambios que necesitan ser escaneados aumenta, y los tipos de vulnerabilidades cambian.
+
+[Secret scanning](https://docs.github.com/code-security/secret-scanning/introduction/about-secret-scanning) detecta credenciales que los agentes podrían incrustar en el código. Esto importa más en los flujos de trabajo agénticos porque los agentes no tienen el mismo instinto que un desarrollador humano de evitar hacer commit de secretos. Si un agente está trabajando a partir de un prompt que incluye una cadena de conexión como contexto, podría reproducir esa cadena en el código generado.
+
+[El escaneo de código con CodeQL](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) identifica patrones de vulnerabilidad en el código generado: inyección SQL, cross-site scripting, path traversal y otras categorías del OWASP Top 10. La fortaleza de CodeQL es que analiza el flujo de datos, no solo la sintaxis, lo que significa que puede detectar vulnerabilidades que se ven correctas en la superficie pero crean caminos explotables a través de la aplicación.
+
+[La revisión de dependencias](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review) evalúa nuevas dependencias que los agentes introducen. Los agentes frecuentemente agregan paquetes para resolver problemas, a veces paquetes que no tienen mantenimiento, tienen vulnerabilidades conocidas o duplican funcionalidad que ya existe en el proyecto. La revisión de dependencias expone estos riesgos antes de que el PR se fusione, dando a los revisores una señal concreta sobre la cual actuar.
+
+Estas herramientas no requieren ninguna configuración especial para el código generado por agentes. Aplican el mismo análisis independientemente de quién creó el cambio. Esa uniformidad es una fortaleza: los agentes son sometidos al mismo estándar de seguridad que los humanos, automáticamente.
+
+### Trazabilidad: logs de auditoría y OIDC
+
+El [log de auditoría](https://docs.github.com/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/about-the-audit-log-for-your-enterprise) de GitHub registra la actividad organizacional a un nivel granular: acceso a repositorios, cambios de permisos, activaciones de workflows y más. Para la gobernanza agéntica, el log de auditoría proporciona la materia prima para responder "qué pasó" después de un incidente.
+
+[Los tokens OIDC en GitHub Actions](https://docs.github.com/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) agregan una segunda dimensión de trazabilidad. Cuando un workflow solicita un token a un proveedor de nube, el token incluye claims que identifican el repositorio, la rama, el workflow y el actor que lo activó. Esto significa que un despliegue activado por un merge creado por un agente puede rastrearse desde el recurso en la nube hasta la ejecución específica del workflow, el PR específico y el commit específico, creando una cadena de custodia de extremo a extremo.
+
+Los equipos deberían asegurar que sus claims de sujeto OIDC sean lo suficientemente granulares para distinguir entre despliegues activados por humanos y los activados por agentes. Un claim de sujeto que incluya la identidad del actor (por ejemplo, `repo:org/repo:ref:refs/heads/main:actor:copilot-agent`) hace posible filtrar y auditar despliegues iniciados por agentes de forma separada de los iniciados por humanos.
+
+### Postura en tiempo de ejecución: Microsoft Defender for Cloud
+
+La detección y la trazabilidad abordan el pipeline. [Microsoft Defender for Cloud](https://azure.microsoft.com/products/defender-for-cloud) extiende la gobernanza al entorno de ejecución, donde el código generado por agentes realmente se ejecuta.
+
+El conector de seguridad DevOps de Defender for Cloud importa los hallazgos de GitHub Advanced Security en un dashboard centralizado, proporcionando una vista única de la postura de seguridad a través de repositorios y recursos en la nube. Esto es particularmente valioso cuando los agentes están generando código en múltiples repositorios, porque consolida la imagen de riesgo que de otro modo estaría fragmentada entre las pestañas de seguridad de los repositorios individuales.
+
+La capa de protección en tiempo de ejecución monitorea las cargas de trabajo desplegadas en busca de comportamiento anómalo: conexiones de red inesperadas, intentos de escalación de privilegios y vulnerabilidades en imágenes de contenedores. Si el código generado por un agente introduce una vulnerabilidad sutil que pasa el escaneo de código pero se manifiesta como comportamiento anómalo en producción, Defender for Cloud proporciona la señal que cierra la brecha.
+
+Como discutí en la [publicación sobre la implementación de GHAS](/blog/ghas-rollout), integrar Defender for Cloud con GitHub Advanced Security crea un ciclo de retroalimentación: las vulnerabilidades detectadas en producción pueden rastrearse hasta el cambio de código que las introdujo, y ese rastro puede informar mejores prompts, un alcance más estricto del agente o consultas adicionales de CodeQL.
+
+---
+
+## Lo que los líderes de ingeniería deberían implementar ahora
+
+Los marcos de gobernanza toman tiempo para madurar. Pero hay pasos concretos que los líderes de ingeniería pueden implementar hoy, antes de que los flujos de trabajo agénticos alcancen una escala donde las brechas de gobernanza se conviertan en incidentes.
+
+**Permisos con alcance para agentes.** Aplica el principio de mínimo privilegio a cada integración de agentes. Si un agente solo necesita modificar código de aplicación, no le des acceso a plantillas de infraestructura o archivos de workflow. Revisa los permisos otorgados al agente de codificación de Copilot y otras integraciones, y redúcelos para que coincidan con los casos de uso reales.
+
+**Puertas de revisión humana obligatorias.** Cada pull request creado por un agente debería requerir aprobación humana antes de hacer merge. Este no es un concepto nuevo. Es la misma regla de protección de rama que ya existe. Pero debería ser una política explícita, no una suposición. Considera requerir un mayor número de revisores para PRs creados por agentes, o requerir revisores con experiencia específica en el dominio.
+
+**Retención de logs de auditoría.** Los logs de auditoría de GitHub tienen períodos de retención configurables. Configúralos para que coincidan con los requisitos de cumplimiento de tu organización, y asegura que la actividad del agente se capture con suficiente detalle para apoyar investigaciones de incidentes. Si tu período de retención es de 90 días y tu ciclo de revisión de seguridad es trimestral, podrías estar eliminando evidencia antes de que sea revisada.
+
+**Política como código con GitHub Rulesets.** Define e impón reglas de repositorio que apliquen a todos los contribuidores, incluyendo agentes. Usa [rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) para requerir verificaciones de estado, restringir modificaciones de rutas de archivos e imponer convenciones de nombres de ramas. Estas reglas están controladas por versión y son auditables, lo que significa que satisfacen requisitos de cumplimiento que la configuración manual no cumple.
+
+**Dashboards de actividad de agentes.** Construye visibilidad sobre cómo se usan los agentes en tu organización. Rastrea métricas como el número de PRs creados por agentes por semana, el porcentaje que requiere revisión después de la revisión humana, y los tipos de hallazgos de seguridad en código generado por agentes. Estas métricas informan decisiones de política y ayudan a calibrar expectativas para la carga de trabajo de revisión.
+
+---
+
+## La gobernanza no es un freno, es un fundamento
+
+Existe la tentación de tratar la gobernanza como aquello que te ralentiza. Cada revisión requerida, cada consulta al log de auditoría, cada restricción de permisos se siente como fricción contra la velocidad que los agentes prometen.
+
+Ese enfoque está invertido. Los equipos que escalarán exitosamente los flujos de trabajo agénticos son los que construyan la capa de gobernanza primero, no los que se muevan rápido y retroadapten controles después de un incidente. La velocidad sin trazabilidad es imprudencia. La autonomía sin responsabilidad es riesgo. La delegación sin control es abdicación.
+
+Los agentes de IA no reducen la necesidad de disciplina en seguridad. Elevan el estándar. Cuando una porción significativa de tu código base es escrita por contribuidores no humanos, el rigor de tus controles de seguridad, la completitud de tus rastros de auditoría y la claridad de tu modelo de responsabilidad se convierten en los diferenciadores entre las organizaciones que envían con confianza y las que envían con ansiedad.
+
+El modelo de seguridad construido para desarrolladores humanos fue un buen fundamento. No es suficiente para lo que viene. La capa de gobernanza que se asienta sobre él, cubriendo auditoría, responsabilidad y control, es lo que los equipos necesitan construir ahora, antes de que la brecha se convierta en un titular.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-04-17-SecurityComplianceAgenticWorkflows.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-04-17-SecurityComplianceAgenticWorkflows.mdx
@@ -1,0 +1,137 @@
+---
+title: "Segurança e conformidade em fluxos de trabalho agênticos: a camada de governança que as equipes estão ignorando"
+description: "À medida que agentes de IA escrevem código, abrem pull requests e acionam implantações, o modelo de segurança construído para a responsabilidade humana se desfaz. As equipes precisam responder três perguntas de governança antes de escalar fluxos de trabalho agênticos com segurança: auditoria, responsabilidade e controle."
+slug: security-compliance-agentic-workflows
+authors: [dsanchezcr]
+tags: [Security, DevSecOps, Agentic AI, GitHub Advanced Security, GitHub Copilot, Microsoft Defender for Cloud, Governance]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-17-security-compliance-agentic/security-compliance-agentic.jpg
+date: 2026-04-17T10:00
+---
+
+# Segurança e conformidade em fluxos de trabalho agênticos: a camada de governança que as equipes estão ignorando
+
+Imagine o seguinte. Um [agente de codificação do GitHub Copilot](https://github.com/features/copilot/agents) pega uma issue, cria uma branch, escreve a implementação em quatro arquivos, adiciona testes e abre um pull request. O CI passa. O escaneamento de código não reporta alertas. Um desenvolvedor revisa o diff, aprova e faz merge. A mudança vai para produção através de um pipeline de implantação automatizado.
+
+Três semanas depois, um teste de penetração descobre que o código gerado pelo agente introduziu uma vulnerabilidade de falsificação de requisição do lado do servidor. O código era sintaticamente limpo, os testes cobriam o caminho feliz, e o revisor não detectou a falha porque a lógica parecia razoável isoladamente. Agora a equipe precisa responder uma pergunta para a qual seu modelo de segurança nunca foi projetado: quem é responsável pelo código que nenhum humano escreveu?
+
+{/* truncate */}
+
+![Segurança e conformidade em fluxos de trabalho agênticos](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-17-security-compliance-agentic/security-compliance-agentic.jpg)
+
+Essa pergunta não é hipotética. É a lacuna de governança que a maioria das organizações de engenharia não abordou, mesmo enquanto adotam ferramentas agênticas em ritmo acelerado. Nas minhas publicações anteriores sobre [implementar GitHub Advanced Security em escala](/blog/ghas-rollout) e [construir pipelines de CI/CD para a era agêntica](/blog/cicd-pipelines-agentic-era), foquei em detecção e verificação. Esta publicação vai mais fundo na camada de governança que fica por baixo de ambas: como você audita o que os agentes fizeram, quem é dono do resultado e como você impõe limites ao comportamento do agente antes que algo dê errado?
+
+---
+
+## O modelo de segurança foi construído para humanos
+
+Cada controle de segurança em um pipeline moderno de entrega de software assume que há um humano atrás do teclado. Regras de proteção de branches existem porque humanos podem fazer push diretamente para main. Revisores obrigatórios existem porque humanos cometem erros que outros humanos podem detectar. O escaneamento de código sinaliza vulnerabilidades porque humanos podem introduzi-las sem perceber. O escaneamento de segredos captura credenciais porque humanos podem copiar uma string de conexão no código-fonte.
+
+Esses controles funcionam porque são calibrados para o comportamento humano. Humanos escrevem código com intenção. Eles entendem o contexto de negócio do que estão construindo. Quando um revisor aprova um pull request, o contrato implícito é que outra pessoa pensante avaliou a mudança e aceitou a responsabilidade por ela.
+
+Os agentes quebram esse contrato de maneiras sutis, mas importantes. Um agente não tem intenção da maneira que um humano tem. Ele gera código que satisfaz um prompt, não código que reflete uma compreensão do modelo de ameaças do sistema. Quando um agente introduz uma dependência, ele não avalia a reputação do mantenedor ou o histórico de segurança do pacote. Quando escreve um endpoint de API, não considera se o endpoint poderia ser abusado em combinação com outros endpoints do sistema.
+
+As ferramentas existentes ainda capturam muitos dos problemas resultantes. [GitHub Advanced Security](https://github.com/enterprise/advanced-security) sinalizará uma vulnerabilidade conhecida em uma dependência adicionada por um agente. [O escaneamento de código com CodeQL](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) detectará padrões de vulnerabilidade comuns no código gerado por agentes. Mas a detecção é apenas uma camada de segurança. A governança requer responder perguntas mais difíceis sobre responsabilidade, rastreabilidade e controle, perguntas que o modelo centrado em humanos nunca precisou fazer porque as respostas eram implícitas.
+
+---
+
+## Três perguntas de governança que toda equipe precisa responder
+
+Quando agentes se tornam contribuidores ativos de uma base de código, três perguntas passam de teóricas a urgentes. Equipes que não as respondem explicitamente vão respondê-las por padrão, geralmente após um incidente, e geralmente com uma resposta que não gostam.
+
+### 1. Auditoria: o que o agente fez e por quê?
+
+A rastreabilidade é a fundação da governança. Se você não pode reconstruir o que um agente fez, quais arquivos modificou, quais prompts recebeu, quais decisões tomou, você não pode investigar incidentes, cumprir requisitos de conformidade nem melhorar seus controles.
+
+A boa notícia é que grande parte dessa infraestrutura já existe. O Git preserva um histórico completo de cada mudança. O GitHub Actions produz logs de auditoria para cada execução de workflow. [A API de log de auditoria do GitHub](https://docs.github.com/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/about-the-audit-log-for-your-enterprise) captura quem acionou o quê, quando e de onde. Os tokens OIDC no GitHub Actions vinculam execuções de workflow a identidades verificáveis, tornando possível distinguir entre uma implantação acionada por um humano e uma acionada por um processo automatizado.
+
+O desafio é que esses sinais estão dispersos. Um único PR criado por um agente pode abranger um histórico de commits do Git, um log de workflow do GitHub Actions, um resultado de escaneamento de código, uma saída de revisão de dependências e um evento de aprovação. Reconstruir o panorama completo requer correlacionar essas fontes. Equipes que levam a governança a sério devem estabelecer políticas de retenção para logs de auditoria, construir dashboards que mostrem a atividade dos agentes como uma categoria distinta e garantir que cada commit criado por um agente carregue metadados que o vinculem à atribuição da tarefa e ao humano que a autorizou.
+
+Este não é um problema novo, mas os fluxos de trabalho agênticos o tornam mais urgente. Quando um humano escreve código, você pode perguntar o que ele estava pensando. Quando um agente escreve código, a trilha de auditoria é a única testemunha.
+
+### 2. Responsabilidade: quem é dono do código gerado por agentes?
+
+A responsabilidade no software sempre foi distribuída. O desenvolvedor que escreve o código, o revisor que o aprova, o líder da equipe que prioriza o trabalho e a organização que envia o produto compartilham responsabilidade. O código gerado por agentes não elimina nenhum desses papéis. Ele adiciona um novo participante cujas responsabilidades são indefinidas.
+
+A resposta prática, por enquanto, é que o humano que delega trabalho a um agente é dono do resultado. Se você atribui uma issue do GitHub ao agente de codificação do Copilot e ele abre um pull request, você é a parte responsável. Você escolheu delegar e é responsável por verificar o resultado. O revisor que aprova o PR compartilha essa responsabilidade, assim como faria com o código de qualquer outro contribuidor.
+
+Mas esse modelo se tensiona em escala. Se um único engenheiro delega vinte tarefas a agentes em um dia e revisa vinte pull requests resultantes, a profundidade de cada revisão inevitavelmente diminui. A superfície de responsabilidade se expande enquanto o orçamento de atenção permanece fixo. Os líderes de engenharia precisam reconhecer essa tensão e definir expectativas realistas sobre quantos PRs criados por agentes um único desenvolvedor deve revisar em um determinado período.
+
+As organizações também devem tornar a responsabilidade explícita em suas políticas de desenvolvimento. Se sua equipe não tem uma declaração escrita sobre quem é dono do código gerado por agentes, escreva uma. Se sua política de revisão não distingue entre pull requests criados por agentes e os criados por humanos, atualize-a. A ambiguidade na responsabilidade é um passivo que cresce com cada commit gerado por agentes que chega à produção.
+
+### 3. Controle: como você governa as permissões e o escopo do agente?
+
+A pergunta de governança mais acionável é também a mais negligenciada: o que o agente tem permissão para fazer?
+
+O agente de codificação do GitHub Copilot opera dentro das permissões concedidas a ele. Ele só pode acessar repositórios aos quais tem acesso e só pode realizar ações que sua integração permite. Mas "pode acessar o repositório" é uma permissão ampla. Um agente designado para corrigir um bug de CSS não precisa da capacidade de modificar workflows do GitHub Actions, templates de infraestrutura ou código de endpoints de API. Sem delimitação de escopo, o agente opera com o conjunto completo de permissões que lhe foram concedidas, não com o conjunto mínimo necessário para a tarefa.
+
+[GitHub Rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) fornecem um mecanismo de controle. Você pode definir regras que restrinjam quais branches podem receber commits, exigir que verificações de status específicas passem antes do merge e impor requisitos de revisão. Essas regras se aplicam igualmente a contribuidores humanos e agentes, o que significa que fornecem uma linha base de controle que não depende do comportamento do próprio agente.
+
+Além dos rulesets, as equipes devem implementar padrões de política como código que validem a saída do agente contra os padrões organizacionais. Isso pode ser tão direto quanto um passo de workflow do GitHub Actions que verifica se um PR criado por um agente modifica arquivos fora de um escopo predefinido, introduz novas dependências sem aprovação ou toca caminhos sensíveis à segurança como arquivos de workflow ou definições de infraestrutura. Minha publicação sobre [pipelines de CI/CD para a era agêntica](/blog/cicd-pipelines-agentic-era) cobre padrões de implementação específicos para essas verificações.
+
+O princípio é o de menor privilégio, aplicado não apenas ao acesso à infraestrutura, mas ao escopo do repositório. Os agentes devem ter as permissões mais restritas que lhes permitam completar suas tarefas atribuídas, e essas permissões devem ser impostas pela plataforma, não pela moderação do próprio agente.
+
+---
+
+## Ferramentas práticas: detecção, rastreabilidade e postura
+
+A governança não é uma única ferramenta. É uma pilha. Cada camada aborda um aspecto diferente do problema, e as camadas se reforçam mutuamente.
+
+### Detecção: GitHub Advanced Security
+
+[GitHub Advanced Security](https://github.com/enterprise/advanced-security) continua sendo a camada principal de detecção para vulnerabilidades em código gerado por agentes. As mesmas capacidades que descrevi na minha [publicação sobre a implementação do GHAS](/blog/ghas-rollout) se aplicam aqui, com uma extensão importante: quando os agentes estão gerando código, o volume de mudanças que precisam ser escaneadas aumenta, e os tipos de vulnerabilidades mudam.
+
+[Secret scanning](https://docs.github.com/code-security/secret-scanning/introduction/about-secret-scanning) captura credenciais que os agentes podem embutir no código. Isso importa mais em fluxos de trabalho agênticos porque os agentes não têm o mesmo instinto que um desenvolvedor humano de evitar fazer commit de segredos. Se um agente está trabalhando a partir de um prompt que inclui uma string de conexão como contexto, ele pode reproduzir essa string no código gerado.
+
+[O escaneamento de código com CodeQL](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) identifica padrões de vulnerabilidade no código gerado: injeção SQL, cross-site scripting, path traversal e outras categorias do OWASP Top 10. A força do CodeQL é que ele analisa o fluxo de dados, não apenas a sintaxe, o que significa que pode capturar vulnerabilidades que parecem corretas na superfície, mas criam caminhos exploráveis através da aplicação.
+
+[A revisão de dependências](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review) avalia novas dependências que os agentes introduzem. Os agentes frequentemente adicionam pacotes para resolver problemas, às vezes pacotes que não têm manutenção, têm vulnerabilidades conhecidas ou duplicam funcionalidade que já existe no projeto. A revisão de dependências expõe esses riscos antes que o PR seja mesclado, dando aos revisores um sinal concreto para agir.
+
+Essas ferramentas não requerem nenhuma configuração especial para código gerado por agentes. Elas aplicam a mesma análise independentemente de quem criou a mudança. Essa uniformidade é uma força: os agentes são submetidos ao mesmo padrão de segurança que os humanos, automaticamente.
+
+### Rastreabilidade: logs de auditoria e OIDC
+
+O [log de auditoria](https://docs.github.com/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/about-the-audit-log-for-your-enterprise) do GitHub registra a atividade organizacional em um nível granular: acesso a repositórios, mudanças de permissões, acionamentos de workflows e mais. Para a governança agêntica, o log de auditoria fornece a matéria-prima para responder "o que aconteceu" após um incidente.
+
+[Os tokens OIDC no GitHub Actions](https://docs.github.com/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) adicionam uma segunda dimensão de rastreabilidade. Quando um workflow solicita um token de um provedor de nuvem, o token inclui claims que identificam o repositório, a branch, o workflow e o ator que o acionou. Isso significa que uma implantação acionada por um merge criado por um agente pode ser rastreada desde o recurso na nuvem até a execução específica do workflow, o PR específico e o commit específico, criando uma cadeia de custódia de ponta a ponta.
+
+As equipes devem garantir que seus claims de sujeito OIDC sejam granulares o suficiente para distinguir entre implantações acionadas por humanos e as acionadas por agentes. Um claim de sujeito que inclui a identidade do ator (por exemplo, `repo:org/repo:ref:refs/heads/main:actor:copilot-agent`) torna possível filtrar e auditar implantações iniciadas por agentes separadamente das iniciadas por humanos.
+
+### Postura em tempo de execução: Microsoft Defender for Cloud
+
+A detecção e a rastreabilidade abordam o pipeline. [Microsoft Defender for Cloud](https://azure.microsoft.com/products/defender-for-cloud) estende a governança ao ambiente de execução, onde o código gerado por agentes realmente é executado.
+
+O conector de segurança DevOps do Defender for Cloud importa as descobertas do GitHub Advanced Security em um dashboard centralizado, fornecendo uma visão única da postura de segurança através de repositórios e recursos na nuvem. Isso é particularmente valioso quando os agentes estão gerando código em múltiplos repositórios, porque consolida a imagem de risco que de outra forma estaria fragmentada entre as abas de segurança dos repositórios individuais.
+
+A camada de proteção em tempo de execução monitora as cargas de trabalho implantadas em busca de comportamento anômalo: conexões de rede inesperadas, tentativas de escalação de privilégios e vulnerabilidades em imagens de contêineres. Se o código gerado por um agente introduz uma vulnerabilidade sutil que passa o escaneamento de código, mas se manifesta como comportamento anômalo em produção, o Defender for Cloud fornece o sinal que fecha a lacuna.
+
+Como discuti na [publicação sobre a implementação do GHAS](/blog/ghas-rollout), integrar o Defender for Cloud com o GitHub Advanced Security cria um ciclo de feedback: vulnerabilidades detectadas em produção podem ser rastreadas até a mudança de código que as introduziu, e esse rastreamento pode informar melhores prompts, escopo mais restrito para o agente ou consultas adicionais do CodeQL.
+
+---
+
+## O que os líderes de engenharia devem implementar agora
+
+Os frameworks de governança levam tempo para amadurecer. Mas há passos concretos que os líderes de engenharia podem implementar hoje, antes que os fluxos de trabalho agênticos alcancem uma escala onde as lacunas de governança se tornem incidentes.
+
+**Permissões com escopo para agentes.** Aplique o princípio de menor privilégio a cada integração de agentes. Se um agente só precisa modificar código de aplicação, não dê acesso a templates de infraestrutura ou arquivos de workflow. Revise as permissões concedidas ao agente de codificação do Copilot e outras integrações, e reduza-as para corresponder aos casos de uso reais.
+
+**Portas de revisão humana obrigatórias.** Cada pull request criado por um agente deve exigir aprovação humana antes do merge. Este não é um conceito novo. É a mesma regra de proteção de branch que já existe. Mas deve ser uma política explícita, não uma suposição. Considere exigir um número maior de revisores para PRs criados por agentes, ou exigir revisores com expertise específica no domínio.
+
+**Retenção de logs de auditoria.** Os logs de auditoria do GitHub têm períodos de retenção configuráveis. Configure-os para corresponder aos requisitos de conformidade da sua organização e garanta que a atividade do agente seja capturada com detalhes suficientes para apoiar investigações de incidentes. Se seu período de retenção é de 90 dias e seu ciclo de revisão de segurança é trimestral, você pode estar excluindo evidências antes que sejam revisadas.
+
+**Política como código com GitHub Rulesets.** Defina e imponha regras de repositório que se apliquem a todos os contribuidores, incluindo agentes. Use [rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) para exigir verificações de status, restringir modificações de caminhos de arquivos e impor convenções de nomes de branches. Essas regras são controladas por versão e auditáveis, o que significa que satisfazem requisitos de conformidade que a configuração manual não cumpre.
+
+**Dashboards de atividade de agentes.** Construa visibilidade sobre como os agentes estão sendo usados em sua organização. Rastreie métricas como o número de PRs criados por agentes por semana, a porcentagem que requer revisão após a revisão humana e os tipos de descobertas de segurança no código gerado por agentes. Essas métricas informam decisões de política e ajudam a calibrar expectativas para a carga de trabalho de revisão.
+
+---
+
+## Governança não é um freio, é uma fundação
+
+Existe a tentação de tratar a governança como aquilo que te desacelera. Cada revisão obrigatória, cada consulta ao log de auditoria, cada restrição de permissão parece atrito contra a velocidade que os agentes prometem.
+
+Essa perspectiva está invertida. As equipes que escalarão fluxos de trabalho agênticos com sucesso são as que construírem a camada de governança primeiro, não as que se moverem rápido e adaptarem controles depois de um incidente. Velocidade sem rastreabilidade é imprudência. Autonomia sem responsabilidade é risco. Delegação sem controle é abdicação.
+
+Os agentes de IA não reduzem a necessidade de disciplina em segurança. Eles elevam o padrão. Quando uma porção significativa da sua base de código é escrita por contribuidores não humanos, o rigor dos seus controles de segurança, a completude das suas trilhas de auditoria e a clareza do seu modelo de responsabilidade se tornam os diferenciadores entre organizações que entregam com confiança e organizações que entregam com ansiedade.
+
+O modelo de segurança construído para desenvolvedores humanos foi uma boa fundação. Não é suficiente para o que vem a seguir. A camada de governança que se assenta sobre ele, cobrindo auditoria, responsabilidade e controle, é o que as equipes precisam construir agora, antes que a lacuna se torne uma manchete.


### PR DESCRIPTION
Add a new blog post about security, compliance, and governance for agentic workflows, plus Spanish and Portuguese translations. Includes frontmatter metadata (tags, date 2026-04-17, image, authors), content explaining audit/accountability/control for agent-authored code, and i18n copies.