### PR TITLE
Add blog: 'IDEs in the AI era' with i18n

### DIFF
--- a/blog/2026-04-19-IDEsInTheAIEra.mdx
+++ b/blog/2026-04-19-IDEsInTheAIEra.mdx
@@ -145,30 +145,6 @@ Not every developer needs the same tools, and pretending otherwise leads to wast
 - **.NET developers on macOS or Linux** have exactly one full IDE option: JetBrains Rider.
 - **Performance engineers** investigating runtime behavior need profiling tools that produce data from actual execution, whether that is Visual Studio's built-in profiler, dotTrace, or dotMemory.
 
-### Roles where the license is harder to justify
-
-- **Web and frontend developers** working in JavaScript, TypeScript, or React. VS Code is the native environment for this work, and Copilot is better integrated here than in any full IDE.
-- **Python developers** doing ML, data science, or scripting. VS Code with Jupyter and Copilot covers the workflow.
-- **DevOps and Platform engineers** working with YAML, Terraform, shell scripts, and infrastructure-as-code. VS Code extensions handle this natively.
-- **Standard .NET API developers** not using Enterprise-exclusive or Professional-specific features. VS Code with the C# Dev Kit and Copilot is a serious alternative.
-- **Full-stack developers** working across many languages. The breadth of VS Code's extension ecosystem outweighs the depth of any single-language IDE.
-
----
-
-## Five questions to ask before renewing
-
-If your team is evaluating tool budgets, these questions cut through the noise:
-
-1. **Which IDE-exclusive features does anyone on the team actually use weekly?** Live Unit Testing, IntelliTrace, architecture layer diagrams, XAML designers, complex solution management. If nobody is using these regularly, the license is paying for capabilities that exist only on paper.
-
-2. **What percentage of your development workflow is now AI-agent-driven?** If most code generation, refactoring, and testing is handled by Copilot or similar tools, the marginal value of IDE-native versions of those features approaches zero.
-
-3. **Are you accounting for the full subscription value?** Azure credits, dev/test pricing, server software licenses, and training benefits are part of the Visual Studio subscription. The budget comparison should be against the total bundle, not just the editor.
-
-4. **Do you have production debugging needs that require runtime instrumentation?** Snapshot Debugger, IntelliTrace, and profiling tools solve problems that no AI can address. If your team regularly investigates production issues on .NET applications, these tools pay for themselves.
-
-5. **What platforms do your developers work on?** Visual Studio is Windows-only. If your team is cross-platform, JetBrains Rider is the only full .NET IDE option. If everyone is on Windows and primarily building web services, VS Code with Copilot is a legitimate primary tool.
-
 ---
 
 ## Where does this go?

--- a/blog/2026-04-19-IDEsInTheAIEra.mdx
+++ b/blog/2026-04-19-IDEsInTheAIEra.mdx
@@ -1,0 +1,182 @@
+---
+title: "Do full IDEs still deserve a seat at the table in the AI era?"
+description: "An honest analysis of when Visual Studio, JetBrains, and other full IDEs still earn their license fee, and when VS Code with AI agents has genuinely made them unnecessary. A role-by-role breakdown for teams evaluating tool budgets in 2026."
+slug: full-ides-ai-era
+authors: [dsanchezcr]
+tags: [Developer Tools, AI, GitHub Copilot, Visual Studio, JetBrains, Software Engineering, Productivity]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-19-idesintheaiera/ides-ai-era.jpg
+date: 2026-04-19T10:00
+---
+
+# Do full IDEs still deserve a seat at the table in the AI era?
+
+A friend of mine canceled his Visual Studio Enterprise subscription in January. He had been using it for years, built multiple production .NET systems in it, and genuinely valued the tooling. But he had spent the last six months doing almost all of his coding inside VS Code with GitHub Copilot Agent Mode, and he could not justify the renewal.
+
+Three weeks later, a background service in production started leaking memory. He tried everything in his VS Code setup: logging, diagnostic analyzers, heap dumps through the CLI. Nothing gave him a clear picture. He reinstated his Enterprise license, opened the Performance Profiler with .NET Object Allocation Tracking, identified the leak in twenty minutes, and fixed it in ten. Then he went back to VS Code for everything else.
+
+That story is the honest version of the IDE question in 2026. Not whether full IDEs are dead, and not whether they remain the default. The real question is sharper: for which roles, which tasks, and which codebases do they still provide capabilities that AI-powered editors cannot replicate? And when you look at the full picture, including what comes bundled with a Visual Studio subscription beyond the IDE itself, the analysis is more nuanced than either side of the debate usually admits.
+
+{/* truncate */}
+
+![Do full IDEs still deserve a seat at the table in the AI era?](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-19-idesintheaiera/ides-ai-era.jpg)
+
+---
+
+## What AI agents genuinely solved
+
+Before making the case for IDEs, I want to be honest about what they have lost.
+
+[The 2025 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2025/) found that 85% of developers now use AI tools regularly, and most report using two to three complementary tools rather than a single winner. That is not a fringe adoption curve. It is a default behavior shift.
+
+Here is what AI agents and AI-augmented editors have effectively commoditized:
+
+- **Code completion and IntelliSense.** Copilot inline completions routinely outperform classic IDE autocomplete, especially for cross-language work and unfamiliar APIs. The advantage that Visual Studio and IntelliJ once held here is functionally gone.
+- **Boilerplate scaffolding.** IDE project templates and wizards were useful when starting a new service or module. AI agents generate context-aware scaffolding faster, with fewer assumptions baked in.
+- **Multi-file refactoring.** Independent testing has shown Cursor Pro completing multi-file refactoring roughly 30% faster than Copilot on comparable tasks. Both work inside VS Code. Neither requires a full IDE.
+- **Test generation.** Copilot and Claude can generate comprehensive test suites from context. This used to be a selling point for IDE test tooling.
+- **Error diagnosis and fix suggestions.** Agent mode in Copilot can identify build errors, propose fixes, apply them, and re-run the build autonomously. The quick-fix lightbulb menu feels quaint by comparison.
+- **Documentation and explanation.** Chat-based interfaces explain code, generate docs, and answer architectural questions better than any IDE's built-in documentation viewer.
+
+IntelliTest, the automated test generation feature exclusive to Visual Studio Enterprise, [was deprecated in VS 2026](https://learn.microsoft.com/visualstudio/test/intellitest-manual). That is a telling signal. When AI generates better tests from natural language prompts than a purpose-built IDE feature does from code analysis, the feature loses its reason to exist.
+
+The features that justified a basic IDE license for most developers five years ago have been absorbed into tools available in a free editor. That is the uncomfortable starting point for this analysis.
+
+---
+
+## Visual Studio Enterprise: what AI cannot replicate
+
+The features that remain exclusive to Visual Studio Enterprise are not marketing checkboxes. They are runtime instrumentation, static analysis, and architectural enforcement tools that operate at layers AI has not reached. Understanding them requires connecting each one to the concrete problem it solves.
+
+### Live Unit Testing
+
+Visual Studio Enterprise runs affected tests automatically as you type and shows pass/fail status inline in the editor gutter. Not after you save. Not after you run a command. As you type. AI tools can generate tests. They cannot execute them reactively and display real-time coverage feedback integrated into the editing experience. For QA engineers and senior .NET developers maintaining large test suites, this is not a convenience. It is a fundamentally different feedback loop that catches regressions before you even finish writing the change that caused them.
+
+### IntelliTrace and time-travel debugging
+
+IntelliTrace records execution history and lets you step backward through it. When a production process crashes and you need to understand the sequence of events that led to the failure, no amount of AI-generated analysis substitutes for replaying the actual execution trace. LLMs can hypothesize about what went wrong based on code patterns and logs. IntelliTrace shows you what actually happened. For teams debugging complex distributed systems, the difference between a hypothesis and a recording is the difference between hours of guesswork and minutes of certainty.
+
+### Architecture layer diagrams and dependency validation
+
+Visual Studio Enterprise can enforce architectural rules at compile time. You define which layers are allowed to reference which other layers, and the build fails if a developer, or an agent, introduces a forbidden dependency. AI can describe architecture in prose. It can even draw diagrams. But it cannot enforce dependency constraints in your build pipeline. For architects maintaining structural integrity across large .NET solutions with dozens of projects, this is not a nice-to-have. It is the only automated mechanism that prevents architectural drift on every single build.
+
+### Snapshot Debugger
+
+For teams running .NET applications on Azure, the Snapshot Debugger captures non-intrusive production snapshots at specific code lines without stopping the process or degrading performance. This is runtime instrumentation, not code intelligence. When you need to understand what is happening in a production service that only misbehaves under real traffic patterns, without attaching a full debugger or redeploying with additional logging, no AI tool provides an equivalent. The data comes from the running process, not from a model's inference about the code.
+
+### Code Clone Detection and Microsoft Fakes
+
+Code Clone Detection performs semantic analysis of duplicate logic across the entire codebase, surfacing duplication that simple text search misses because the implementations differ syntactically but perform the same operation. AI can find duplication if you ask it to inspect specific files, but Visual Studio does it passively across millions of lines as part of its continuous analysis. Microsoft Fakes provides shim and stub frameworks that isolate unit tests from external dependencies at the CLR level, and Test Impact Analysis identifies which tests need to run based on which code changed. No AI tool provides test impact analysis at the runtime level.
+
+---
+
+## Visual Studio Professional: the middle tier under pressure
+
+Visual Studio Professional sits in a more contested position in 2026, but it still has a concrete case for specific scenarios. Its value is no longer about IntelliSense or refactoring, where VS Code with Copilot has caught up. It is about the project system, the build integration, and the designer tooling that VS Code does not yet match.
+
+### Where Professional still earns its cost
+
+- **Windows desktop development.** WPF, WinForms, and MAUI visual designers remain exclusive to Visual Studio. If your team builds Windows desktop applications, there is no VS Code equivalent for drag-and-drop form design, XAML visual preview, or the MAUI Hot Reload experience. This is not a marginal difference. It is the presence or absence of an entire development workflow.
+- **MSBuild and complex solution management.** VS Code's C# Dev Kit handles single-project and small multi-project solutions well. But for solutions with 20, 50, or 100+ projects, with complex build ordering, conditional compilation, and platform targeting, Visual Studio's project system and Solution Explorer are materially better at managing the complexity. Build configuration across Debug/Release/custom profiles, NuGet package management with visual conflict resolution, and multi-targeting (.NET Framework + .NET 9 in the same solution) are areas where the IDE's maturity shows.
+- **Integrated profiling and diagnostics.** While the deepest profiling tools belong to the Enterprise tier or third parties, Visual Studio Professional includes the built-in Performance Profiler with CPU usage, memory allocation, and .NET object allocation analysis. These are lighter than Enterprise-grade tools but significantly more integrated than anything available in VS Code.
+- **Azure integration tooling.** Connected Services, cloud resource provisioning, and the Azure publishing workflow are tighter in Visual Studio Professional than in any VS Code extension. For teams deploying to Azure App Service, Azure Functions, or Azure Container Apps, the publish wizard and deployment profiles reduce friction compared to CLI-only workflows.
+- **CodeLens.** Inline references, test status, and Git blame information displayed directly in the editor for every method and class. VS Code has extensions that approximate this, but the Visual Studio implementation is deeper and more reliable across large solutions.
+
+### The honest assessment
+
+For .NET developers building web APIs and microservices who are comfortable with the terminal and already using Copilot, VS Code with C# Dev Kit is a legitimate alternative to Professional. The gap has narrowed considerably. But for teams building desktop applications, managing complex multi-project solutions, or relying on visual designers, Professional remains the right tool, not because of tradition, but because the specific capabilities have no equivalent elsewhere.
+
+---
+
+## The Visual Studio subscription: beyond the IDE
+
+One dimension that pure IDE-vs-editor comparisons consistently overlook is what comes bundled with a Visual Studio subscription. The license is not just an IDE license. It is a subscription that includes development and testing resources that affect the total cost of engineering operations.
+
+### What the subscription includes
+
+- **Monthly Azure credits.** Visual Studio Professional subscribers receive $50/month in Azure credits. Enterprise subscribers receive $150/month. For individual developers or small teams, these credits can cover development and test environments, CI/CD pipeline compute, or sandbox deployments entirely. That is $600 to $1,800 per year in Azure spending that is already included in the subscription cost.
+- **Azure Dev/Test pricing.** Subscribers get discounted rates on Azure services specifically for development and testing workloads. Windows Virtual Machines, for example, are billed at Linux rates with no additional Windows license charge. For teams running test environments, staging environments, or load-testing infrastructure on Azure, the savings compound.
+- **Access to the full Microsoft software catalog for dev/test.** Visual Studio subscriptions include licenses for Windows Server, SQL Server, and other Microsoft server software for development and testing purposes. Teams that would otherwise need separate licenses for test environments avoid that cost entirely.
+- **Pluralsight, LinkedIn Learning, and training benefits.** Enterprise subscriptions include access to training platforms. Whether these get used depends on the team's learning culture, but they represent real line-item value that offsets the subscription cost.
+- **Azure DevOps.** Visual Studio subscribers get enhanced Azure DevOps features, including a Basic + Test Plans license. For teams already using Azure DevOps for work tracking and CI/CD, this eliminates a separate per-user cost.
+- **Technical support incidents.** Professional includes two and Enterprise includes four advisory support incidents per year with Microsoft. These are not unlimited, but a single well-timed support incident on a production-blocking issue can recover the entire annual subscription cost.
+
+---
+
+## JetBrains: the cross-platform and language-specialist case
+
+JetBrains IDEs deserve specific attention not as competitors to Visual Studio in the .NET space, but as specialists in areas where they have no equivalent.
+
+### Where JetBrains stands apart
+
+- **Rider for .NET on macOS and Linux.** Visual Studio Enterprise is Windows-only. For .NET teams where developers use macOS or Linux, JetBrains Rider is the only full IDE option. It also ships with dotTrace and dotMemory for performance and memory profiling, capabilities that are either Enterprise-exclusive or third-party in the Visual Studio ecosystem.
+- **DataGrip for multi-database work.** DataGrip provides schema-aware navigation, query execution, data editing, and ER diagrams across PostgreSQL, MongoDB, Redis, BigQuery, and dozens of other databases in a unified workspace. No VS Code extension provides the same depth of schema understanding, cross-database query capabilities, or live data exploration. For database engineers and backend developers who work across multiple database engines daily, DataGrip fills a gap that neither Visual Studio nor VS Code covers well.
+- **Language-specific depth.** IntelliJ IDEA for Java/Kotlin, PyCharm for Python, GoLand for Go, and PhpStorm for PHP each provide semantic models purpose-built for their language. Type inference, flow analysis, and framework-specific inspections operate at a depth that general-purpose extensions cannot fully match.
+
+### AI inside the IDE
+
+JetBrains now has Claude Agent natively integrated alongside Junie in a multi-agent experience within the IDE. The AI agents operate within the IDE's semantic model, sharing the same abstract syntax tree understanding that drives the refactoring engine. This is architecturally different from VS Code, where AI agents primarily work from text and embeddings. The practical effect is that AI-assisted refactoring inside a JetBrains IDE produces more structurally accurate results on large codebases.
+
+---
+
+## The counterintuitive argument: AI makes rich tool environments more valuable, not less
+
+The "IDEs are dead" narrative misses a structural point. AI agents are most powerful when they have a rich tool environment to work within. An agent that operates inside Visual Studio's or Rider's semantic model, with access to the same type system, dependency graph, and build context that the IDE uses for its own refactoring, produces higher-quality output than an agent working from text alone.
+
+For simple projects in a single language, VS Code provides enough context for AI agents to work effectively. For large .NET solutions, multi-project Java applications, or codebases with strict architectural constraints, the IDE's semantic depth is not overhead. It is the foundation that makes the AI layer more accurate.
+
+The implication is worth stating plainly: AI agents do not make rich semantic environments less valuable. They make them more valuable, because the agent's output quality is proportional to the depth of the context it operates within.
+
+---
+
+## The role-by-role breakdown
+
+Not every developer needs the same tools, and pretending otherwise leads to wasted budgets in both directions: paying for features nobody uses, or saving money on licenses only to lose hours when a specific capability is needed.
+
+### Roles where full IDEs still earn their cost
+
+- **Software Architects** maintaining large .NET solutions need dependency validation and architecture layer enforcement at the build level. No AI tool replicates this.
+- **QA and Test Engineers** on .NET projects benefit measurably from Live Unit Testing, IntelliTrace, and Microsoft Fakes. These are daily-use features, not occasional conveniences.
+- **SRE and Platform teams** running Azure-hosted .NET applications need Snapshot Debugger for production diagnostics that cannot be reproduced locally.
+- **Windows desktop developers** building WPF, WinForms, or MAUI applications rely on Visual Studio's designer tooling, which has no equivalent in VS Code.
+- **.NET teams with complex solutions** managing 20+ projects with conditional compilation, multi-targeting, and platform-specific builds benefit from Visual Studio Professional's project system maturity.
+- **Database engineers** working across multiple database engines benefit from DataGrip in ways that no VS Code extension matches.
+- **.NET developers on macOS or Linux** have exactly one full IDE option: JetBrains Rider.
+- **Performance engineers** investigating runtime behavior need profiling tools that produce data from actual execution, whether that is Visual Studio's built-in profiler, dotTrace, or dotMemory.
+
+### Roles where the license is harder to justify
+
+- **Web and frontend developers** working in JavaScript, TypeScript, or React. VS Code is the native environment for this work, and Copilot is better integrated here than in any full IDE.
+- **Python developers** doing ML, data science, or scripting. VS Code with Jupyter and Copilot covers the workflow.
+- **DevOps and Platform engineers** working with YAML, Terraform, shell scripts, and infrastructure-as-code. VS Code extensions handle this natively.
+- **Standard .NET API developers** not using Enterprise-exclusive or Professional-specific features. VS Code with the C# Dev Kit and Copilot is a serious alternative.
+- **Full-stack developers** working across many languages. The breadth of VS Code's extension ecosystem outweighs the depth of any single-language IDE.
+
+---
+
+## Five questions to ask before renewing
+
+If your team is evaluating tool budgets, these questions cut through the noise:
+
+1. **Which IDE-exclusive features does anyone on the team actually use weekly?** Live Unit Testing, IntelliTrace, architecture layer diagrams, XAML designers, complex solution management. If nobody is using these regularly, the license is paying for capabilities that exist only on paper.
+
+2. **What percentage of your development workflow is now AI-agent-driven?** If most code generation, refactoring, and testing is handled by Copilot or similar tools, the marginal value of IDE-native versions of those features approaches zero.
+
+3. **Are you accounting for the full subscription value?** Azure credits, dev/test pricing, server software licenses, and training benefits are part of the Visual Studio subscription. The budget comparison should be against the total bundle, not just the editor.
+
+4. **Do you have production debugging needs that require runtime instrumentation?** Snapshot Debugger, IntelliTrace, and profiling tools solve problems that no AI can address. If your team regularly investigates production issues on .NET applications, these tools pay for themselves.
+
+5. **What platforms do your developers work on?** Visual Studio is Windows-only. If your team is cross-platform, JetBrains Rider is the only full .NET IDE option. If everyone is on Windows and primarily building web services, VS Code with Copilot is a legitimate primary tool.
+
+---
+
+## Where does this go?
+
+The trajectory is clear, even if the timeline is not. AI agents will continue to improve at code generation, refactoring, testing, and even architectural reasoning. The feature set that full IDEs can claim as exclusively theirs will continue to narrow.
+
+But that narrowing has a floor. Runtime instrumentation, production profiling, live dependency enforcement, visual designers, and deep database intelligence are not code generation problems. They are observation, constraint, and design-surface problems that require access to running systems, build pipelines, execution traces, and rendering engines. AI models do not have that access today, and gaining it would require architectural changes that go beyond improving the models themselves.
+
+The honest position is this: full IDEs are no longer the default choice for most developers. They are the specialist choice for specific roles, specific problems, and specific stages of software maturity. That is not a diminishment. It is a clarification. The best tools in software have always been the ones that solve a specific problem better than anything else, and the IDE features that survive the AI era are precisely the ones that meet that standard.
+
+The developers and teams that get this right will not pick one tool and commit to it as an identity. They will build a toolchain that matches their actual work: VS Code and Copilot for the daily workflow where AI-first editing is faster, and a full IDE for the moments where runtime depth, architectural enforcement, or design-surface precision makes the difference between debugging for twenty minutes and debugging for two days.

--- a/i18n/es/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
@@ -145,30 +145,6 @@ No todos los desarrolladores necesitan las mismas herramientas, y pretender lo c
 - **Desarrolladores .NET en macOS o Linux** tienen exactamente una opción de IDE completo: JetBrains Rider.
 - **Ingenieros de Rendimiento** que investigan el comportamiento en tiempo de ejecución necesitan herramientas de perfilado que producen datos de la ejecución real, ya sea el perfilador integrado de Visual Studio, dotTrace o dotMemory.
 
-### Roles donde la licencia es más difícil de justificar
-
-- **Desarrolladores web y frontend** que trabajan en JavaScript, TypeScript o React. VS Code es el entorno nativo para este trabajo, y Copilot está mejor integrado aquí que en cualquier IDE completo.
-- **Desarrolladores Python** que hacen ML, ciencia de datos o scripting. VS Code con Jupyter y Copilot cubre el flujo de trabajo.
-- **Ingenieros DevOps y de Plataforma** que trabajan con YAML, Terraform, scripts de shell e infraestructura como código. Las extensiones de VS Code manejan esto de forma nativa.
-- **Desarrolladores estándar de APIs .NET** que no usan funciones exclusivas de Enterprise o específicas de Professional. VS Code con C# Dev Kit y Copilot es una alternativa seria.
-- **Desarrolladores full-stack** que trabajan en múltiples lenguajes. La amplitud del ecosistema de extensiones de VS Code supera la profundidad de cualquier IDE de un solo lenguaje.
-
----
-
-## Cinco preguntas que hacer antes de renovar
-
-Si tu equipo está evaluando presupuestos de herramientas, estas preguntas cortan a través del ruido:
-
-1. **¿Qué funciones exclusivas del IDE alguien del equipo realmente usa semanalmente?** Live Unit Testing, IntelliTrace, diagramas de capas de arquitectura, diseñadores XAML, gestión de soluciones complejas. Si nadie las usa regularmente, la licencia está pagando por capacidades que existen solo en papel.
-
-2. **¿Qué porcentaje de tu flujo de trabajo de desarrollo ahora es impulsado por agentes de IA?** Si la mayoría de la generación de código, refactorización y testing es manejada por Copilot o herramientas similares, el valor marginal de las versiones nativas del IDE de esas funciones se acerca a cero.
-
-3. **¿Estás contabilizando el valor completo de la suscripción?** Créditos de Azure, precios dev/test, licencias de software de servidor y beneficios de capacitación son parte de la suscripción de Visual Studio. La comparación de presupuesto debe ser contra el paquete total, no solo el editor.
-
-4. **¿Tienen necesidades de depuración de producción que requieran instrumentación en tiempo de ejecución?** Snapshot Debugger, IntelliTrace y herramientas de perfilado resuelven problemas que ninguna IA puede abordar. Si tu equipo investiga regularmente problemas de producción en aplicaciones .NET, estas herramientas se pagan solas.
-
-5. **¿En qué plataformas trabajan tus desarrolladores?** Visual Studio es solo para Windows. Si tu equipo es multiplataforma, JetBrains Rider es la única opción de IDE .NET completo. Si todos están en Windows y construyen principalmente servicios web, VS Code con Copilot es una herramienta primaria legítima.
-
 ---
 
 ## ¿Hacia dónde va esto?

--- a/i18n/es/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
@@ -1,0 +1,182 @@
+---
+title: "¿Los IDEs completos aún merecen un lugar en la mesa en la era de la IA?"
+description: "Un análisis honesto de cuándo Visual Studio, JetBrains y otros IDEs completos aún justifican su costo de licencia, y cuándo VS Code con agentes de IA los ha hecho genuinamente innecesarios. Un desglose por rol para equipos que evalúan presupuestos de herramientas en 2026."
+slug: full-ides-ai-era
+authors: [dsanchezcr]
+tags: [Developer Tools, AI, GitHub Copilot, Visual Studio, JetBrains, Software Engineering, Productivity]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-19-idesintheaiera/ides-ai-era.jpg
+date: 2026-04-19T10:00
+---
+
+# ¿Los IDEs completos aún merecen un lugar en la mesa en la era de la IA?
+
+Un amigo mío canceló su suscripción de Visual Studio Enterprise en enero. La había usado durante años, construyó múltiples sistemas .NET de producción con ella, y genuinamente valoraba las herramientas. Pero había pasado los últimos seis meses haciendo casi toda su programación dentro de VS Code con GitHub Copilot Agent Mode, y no podía justificar la renovación.
+
+Tres semanas después, un servicio en segundo plano en producción empezó a tener fugas de memoria. Intentó todo en su configuración de VS Code: logging, analizadores de diagnóstico, volcados de heap a través de la CLI. Nada le daba una imagen clara. Reinstaló su licencia Enterprise, abrió el Performance Profiler con .NET Object Allocation Tracking, identificó la fuga en veinte minutos y la corrigió en diez. Luego volvió a VS Code para todo lo demás.
+
+Esa historia es la versión honesta de la pregunta sobre los IDEs en 2026. No si los IDEs completos están muertos, ni si siguen siendo la opción predeterminada. La pregunta real es más precisa: ¿para qué roles, qué tareas y qué bases de código siguen proporcionando capacidades que los editores potenciados por IA no pueden replicar? Y cuando miras el panorama completo, incluyendo lo que viene incluido con una suscripción de Visual Studio más allá del IDE mismo, el análisis es más matizado de lo que cualquier lado del debate suele admitir.
+
+{/* truncate */}
+
+![¿Los IDEs completos aún merecen un lugar en la mesa en la era de la IA?](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-19-idesintheaiera/ides-ai-era.jpg)
+
+---
+
+## Lo que los agentes de IA genuinamente resolvieron
+
+Antes de presentar el caso a favor de los IDEs, quiero ser honesto sobre lo que han perdido.
+
+[La Encuesta de Desarrolladores de Stack Overflow 2025](https://survey.stackoverflow.co/2025) encontró que el 85% de los desarrolladores ahora usan herramientas de IA regularmente, y la mayoría reporta usar dos o tres herramientas complementarias en lugar de una sola ganadora. Eso no es una curva de adopción marginal. Es un cambio de comportamiento predeterminado.
+
+Esto es lo que los agentes de IA y los editores aumentados con IA han comoditizado efectivamente:
+
+- **Autocompletado de código e IntelliSense.** Las sugerencias inline de Copilot superan rutinariamente al autocompletado clásico de los IDEs, especialmente para trabajo en múltiples lenguajes y APIs desconocidas. La ventaja que Visual Studio e IntelliJ tenían aquí ha desaparecido funcionalmente.
+- **Scaffolding de código repetitivo.** Las plantillas de proyecto y asistentes de los IDEs eran útiles al iniciar un nuevo servicio o módulo. Los agentes de IA generan scaffolding contextualizado más rápido, con menos suposiciones incorporadas.
+- **Refactorización de múltiples archivos.** Pruebas independientes han mostrado que Cursor Pro completa refactorizaciones de múltiples archivos aproximadamente un 30% más rápido que Copilot en tareas comparables. Ambos funcionan dentro de VS Code. Ninguno requiere un IDE completo.
+- **Generación de pruebas.** Copilot y Claude pueden generar suites de pruebas completas a partir del contexto. Esto solía ser un punto de venta para las herramientas de testing de los IDEs.
+- **Diagnóstico de errores y sugerencias de corrección.** El modo agente en Copilot puede identificar errores de compilación, proponer correcciones, aplicarlas y volver a ejecutar la compilación de forma autónoma. El menú de corrección rápida se siente anticuado en comparación.
+- **Documentación y explicación.** Las interfaces basadas en chat explican código, generan documentación y responden preguntas de arquitectura mejor que cualquier visor de documentación integrado en un IDE.
+
+IntelliTest, la función de generación automatizada de pruebas exclusiva de Visual Studio Enterprise, [fue deprecada en VS 2026](https://learn.microsoft.com/visualstudio/test/intellitest-manual). Es una señal reveladora. Cuando la IA genera mejores pruebas a partir de prompts en lenguaje natural de lo que una función de IDE diseñada específicamente lo hace a partir del análisis de código, la función pierde su razón de existir.
+
+Las funciones que justificaban una licencia básica de IDE para la mayoría de los desarrolladores hace cinco años han sido absorbidas por herramientas disponibles en un editor gratuito. Ese es el punto de partida incómodo de este análisis.
+
+---
+
+## Visual Studio Enterprise: lo que la IA no puede replicar
+
+Las funciones que permanecen exclusivas de Visual Studio Enterprise no son casillas de verificación de marketing. Son herramientas de instrumentación en tiempo de ejecución, análisis estático y aplicación arquitectónica que operan en capas que la IA no ha alcanzado. Entenderlas requiere conectar cada una con el problema concreto que resuelve.
+
+### Live Unit Testing
+
+Visual Studio Enterprise ejecuta las pruebas afectadas automáticamente mientras escribes y muestra el estado de aprobado/fallido en línea en el margen del editor. No después de guardar. No después de ejecutar un comando. Mientras escribes. Las herramientas de IA pueden generar pruebas. No pueden ejecutarlas de forma reactiva y mostrar retroalimentación de cobertura en tiempo real integrada en la experiencia de edición. Para ingenieros de QA y desarrolladores senior de .NET que mantienen grandes suites de pruebas, esto no es una conveniencia. Es un ciclo de retroalimentación fundamentalmente diferente que detecta regresiones antes de que termines de escribir el cambio que las causó.
+
+### IntelliTrace y depuración de viaje en el tiempo
+
+IntelliTrace registra el historial de ejecución y te permite retroceder paso a paso a través de él. Cuando un proceso de producción falla y necesitas entender la secuencia de eventos que llevó al fallo, ninguna cantidad de análisis generado por IA sustituye la reproducción del rastro de ejecución real. Los LLMs pueden hipotetizar sobre lo que salió mal basándose en patrones de código y logs. IntelliTrace te muestra lo que realmente sucedió. Para equipos que depuran sistemas distribuidos complejos, la diferencia entre una hipótesis y una grabación es la diferencia entre horas de conjeturas y minutos de certeza.
+
+### Diagramas de capas de arquitectura y validación de dependencias
+
+Visual Studio Enterprise puede aplicar reglas arquitectónicas en tiempo de compilación. Defines qué capas tienen permitido referenciar a qué otras capas, y la compilación falla si un desarrollador, o un agente, introduce una dependencia prohibida. La IA puede describir la arquitectura en prosa. Incluso puede dibujar diagramas. Pero no puede aplicar restricciones de dependencia en tu pipeline de compilación. Para arquitectos que mantienen la integridad estructural de grandes soluciones .NET con docenas de proyectos, esto no es algo opcional. Es el único mecanismo automatizado que previene la deriva arquitectónica en cada compilación.
+
+### Snapshot Debugger
+
+Para equipos que ejecutan aplicaciones .NET en Azure, el Snapshot Debugger captura instantáneas de producción no intrusivas en líneas de código específicas sin detener el proceso ni degradar el rendimiento. Esto es instrumentación en tiempo de ejecución, no inteligencia de código. Cuando necesitas entender qué está pasando en un servicio de producción que solo se comporta mal bajo patrones de tráfico real, sin adjuntar un depurador completo o redesplegar con logging adicional, ninguna herramienta de IA proporciona un equivalente. Los datos vienen del proceso en ejecución, no de la inferencia de un modelo sobre el código.
+
+### Detección de clones de código y Microsoft Fakes
+
+La Detección de Clones de Código realiza análisis semántico de lógica duplicada en toda la base de código, detectando duplicación que la búsqueda simple de texto no encuentra porque las implementaciones difieren sintácticamente pero realizan la misma operación. La IA puede encontrar duplicación si le pides que inspeccione archivos específicos, pero Visual Studio lo hace pasivamente a través de millones de líneas como parte de su análisis continuo. Microsoft Fakes proporciona frameworks de shim y stub que aíslan las pruebas unitarias de dependencias externas a nivel de CLR, y el Análisis de Impacto de Pruebas identifica qué pruebas necesitan ejecutarse basándose en qué código cambió. Ninguna herramienta de IA proporciona análisis de impacto de pruebas a nivel de tiempo de ejecución.
+
+---
+
+## Visual Studio Professional: el nivel intermedio bajo presión
+
+Visual Studio Professional se encuentra en una posición más disputada en 2026, pero aún tiene un caso concreto para escenarios específicos. Su valor ya no se trata de IntelliSense o refactorización, donde VS Code con Copilot se ha puesto al día. Se trata del sistema de proyectos, la integración de compilación y las herramientas de diseño que VS Code aún no iguala.
+
+### Donde Professional aún justifica su costo
+
+- **Desarrollo de escritorio Windows.** Los diseñadores visuales de WPF, WinForms y MAUI siguen siendo exclusivos de Visual Studio. Si tu equipo construye aplicaciones de escritorio Windows, no hay equivalente en VS Code para el diseño de formularios de arrastrar y soltar, la vista previa visual de XAML o la experiencia de MAUI Hot Reload. Esta no es una diferencia marginal. Es la presencia o ausencia de un flujo de trabajo de desarrollo completo.
+- **MSBuild y gestión de soluciones complejas.** El C# Dev Kit de VS Code maneja bien proyectos individuales y soluciones con pocos proyectos. Pero para soluciones con 20, 50 o más de 100 proyectos, con ordenamiento de compilación complejo, compilación condicional y targeting de plataformas, el sistema de proyectos de Visual Studio y el Explorador de Soluciones son materialmente mejores para gestionar la complejidad. La configuración de compilación entre perfiles Debug/Release/personalizados, la gestión de paquetes NuGet con resolución visual de conflictos y el multi-targeting (.NET Framework + .NET 9 en la misma solución) son áreas donde la madurez del IDE se nota.
+- **Perfilado y diagnósticos integrados.** Aunque las herramientas de perfilado más profundas pertenecen al nivel Enterprise o a terceros, Visual Studio Professional incluye el Performance Profiler integrado con análisis de uso de CPU, asignación de memoria y asignación de objetos .NET. Son más ligeros que las herramientas de nivel Enterprise pero significativamente más integrados que cualquier cosa disponible en VS Code.
+- **Herramientas de integración con Azure.** Connected Services, aprovisionamiento de recursos en la nube y el flujo de trabajo de publicación en Azure son más estrechos en Visual Studio Professional que en cualquier extensión de VS Code. Para equipos que despliegan en Azure App Service, Azure Functions o Azure Container Apps, el asistente de publicación y los perfiles de despliegue reducen la fricción comparado con flujos de trabajo solo de CLI.
+- **CodeLens.** Referencias inline, estado de pruebas e información de Git blame mostrados directamente en el editor para cada método y clase. VS Code tiene extensiones que aproximan esto, pero la implementación de Visual Studio es más profunda y confiable en soluciones grandes.
+
+### La evaluación honesta
+
+Para desarrolladores .NET que construyen APIs web y microservicios, que están cómodos con la terminal y ya usan Copilot, VS Code con C# Dev Kit es una alternativa legítima a Professional. La brecha se ha reducido considerablemente. Pero para equipos que construyen aplicaciones de escritorio, gestionan soluciones complejas con múltiples proyectos o dependen de diseñadores visuales, Professional sigue siendo la herramienta correcta, no por tradición, sino porque las capacidades específicas no tienen equivalente en otro lugar.
+
+---
+
+## La suscripción de Visual Studio: más allá del IDE
+
+Una dimensión que las comparaciones puras de IDE-vs-editor consistentemente pasan por alto es lo que viene incluido con una suscripción de Visual Studio. La licencia no es solo una licencia de IDE. Es una suscripción que incluye recursos de desarrollo y pruebas que afectan el costo total de las operaciones de ingeniería.
+
+### Lo que incluye la suscripción
+
+- **Créditos mensuales de Azure.** Los suscriptores de Visual Studio Professional reciben $50/mes en créditos de Azure. Los suscriptores Enterprise reciben $150/mes. Para desarrolladores individuales o equipos pequeños, estos créditos pueden cubrir entornos de desarrollo y pruebas, computación de pipelines de CI/CD o despliegues sandbox por completo. Son $600 a $1,800 por año en gasto de Azure que ya está incluido en el costo de la suscripción.
+- **Precios Azure Dev/Test.** Los suscriptores obtienen tarifas con descuento en servicios de Azure específicamente para cargas de trabajo de desarrollo y pruebas. Las Máquinas Virtuales Windows, por ejemplo, se facturan a tarifas de Linux sin cargo adicional por licencia de Windows. Para equipos que ejecutan entornos de prueba, entornos de staging o infraestructura de pruebas de carga en Azure, los ahorros se acumulan.
+- **Acceso al catálogo completo de software Microsoft para dev/test.** Las suscripciones de Visual Studio incluyen licencias de Windows Server, SQL Server y otro software de servidor de Microsoft para propósitos de desarrollo y pruebas. Los equipos que de otro modo necesitarían licencias separadas para entornos de prueba evitan ese costo por completo.
+- **Pluralsight, LinkedIn Learning y beneficios de capacitación.** Las suscripciones Enterprise incluyen acceso a plataformas de capacitación. Si se usan o no depende de la cultura de aprendizaje del equipo, pero representan un valor real como línea de presupuesto que compensa el costo de la suscripción.
+- **Azure DevOps.** Los suscriptores de Visual Studio obtienen funciones mejoradas de Azure DevOps, incluyendo una licencia Basic + Test Plans. Para equipos que ya usan Azure DevOps para seguimiento de trabajo y CI/CD, esto elimina un costo separado por usuario.
+- **Incidentes de soporte técnico.** Professional incluye dos e Enterprise incluye cuatro incidentes de soporte consultivo por año con Microsoft. No son ilimitados, pero un solo incidente de soporte bien cronometrado en un problema que bloquea la producción puede recuperar el costo de toda la suscripción anual.
+
+---
+
+## JetBrains: el caso multiplataforma y de especialización por lenguaje
+
+Los IDEs de JetBrains merecen atención específica no como competidores de Visual Studio en el espacio .NET, sino como especialistas en áreas donde no tienen equivalente.
+
+### Donde JetBrains se diferencia
+
+- **Rider para .NET en macOS y Linux.** Visual Studio Enterprise es solo para Windows. Para equipos .NET donde los desarrolladores usan macOS o Linux, JetBrains Rider es la única opción de IDE completo. También incluye dotTrace y dotMemory para perfilado de rendimiento y memoria, capacidades que son exclusivas de Enterprise o de terceros en el ecosistema de Visual Studio.
+- **DataGrip para trabajo con múltiples bases de datos.** DataGrip proporciona navegación con conocimiento del esquema, ejecución de consultas, edición de datos y diagramas ER a través de PostgreSQL, MongoDB, Redis, BigQuery y docenas de otras bases de datos en un espacio de trabajo unificado. Ninguna extensión de VS Code proporciona la misma profundidad de comprensión del esquema, capacidades de consulta entre bases de datos o exploración de datos en vivo. Para ingenieros de bases de datos y desarrolladores backend que trabajan con múltiples motores de bases de datos diariamente, DataGrip llena un vacío que ni Visual Studio ni VS Code cubren bien.
+- **Profundidad específica por lenguaje.** IntelliJ IDEA para Java/Kotlin, PyCharm para Python, GoLand para Go y PhpStorm para PHP proporcionan modelos semánticos construidos específicamente para su lenguaje. La inferencia de tipos, el análisis de flujo y las inspecciones específicas del framework operan a una profundidad que las extensiones de propósito general no pueden igualar completamente.
+
+### IA dentro del IDE
+
+JetBrains ahora tiene Claude Agent nativamente integrado junto con Junie en una experiencia multi-agente dentro del IDE. Los agentes de IA operan dentro del modelo semántico del IDE, compartiendo la misma comprensión del árbol de sintaxis abstracta que impulsa el motor de refactorización. Esto es arquitectónicamente diferente de VS Code, donde los agentes de IA trabajan principalmente a partir de texto y embeddings. El efecto práctico es que la refactorización asistida por IA dentro de un IDE de JetBrains produce resultados más estructuralmente precisos en bases de código grandes.
+
+---
+
+## El argumento contraintuitivo: la IA hace los entornos de herramientas ricos más valiosos, no menos
+
+La narrativa de "los IDEs están muertos" pasa por alto un punto estructural. Los agentes de IA son más poderosos cuando tienen un entorno de herramientas rico en el cual trabajar. Un agente que opera dentro del modelo semántico de Visual Studio o Rider, con acceso al mismo sistema de tipos, grafo de dependencias y contexto de compilación que el IDE usa para su propia refactorización, produce resultados de mayor calidad que un agente trabajando solo desde texto.
+
+Para proyectos simples en un solo lenguaje, VS Code proporciona suficiente contexto para que los agentes de IA trabajen efectivamente. Para grandes soluciones .NET, aplicaciones Java con múltiples proyectos o bases de código con restricciones arquitectónicas estrictas, la profundidad semántica del IDE no es sobrecarga. Es la base que hace la capa de IA más precisa.
+
+La implicación vale la pena declararla claramente: los agentes de IA no hacen los entornos semánticos ricos menos valiosos. Los hacen más valiosos, porque la calidad del resultado del agente es proporcional a la profundidad del contexto en el que opera.
+
+---
+
+## El desglose por rol
+
+No todos los desarrolladores necesitan las mismas herramientas, y pretender lo contrario lleva a presupuestos desperdiciados en ambas direcciones: pagando por funciones que nadie usa, o ahorrando dinero en licencias solo para perder horas cuando se necesita una capacidad específica.
+
+### Roles donde los IDEs completos aún justifican su costo
+
+- **Arquitectos de Software** que mantienen grandes soluciones .NET necesitan validación de dependencias y aplicación de capas de arquitectura a nivel de compilación. Ninguna herramienta de IA replica esto.
+- **Ingenieros de QA y Testing** en proyectos .NET se benefician mediblemente de Live Unit Testing, IntelliTrace y Microsoft Fakes. Son funciones de uso diario, no conveniencias ocasionales.
+- **Equipos de SRE y Plataforma** que ejecutan aplicaciones .NET alojadas en Azure necesitan Snapshot Debugger para diagnósticos de producción que no pueden reproducirse localmente.
+- **Desarrolladores de escritorio Windows** que construyen aplicaciones WPF, WinForms o MAUI dependen de las herramientas de diseño de Visual Studio, que no tienen equivalente en VS Code.
+- **Equipos .NET con soluciones complejas** que gestionan más de 20 proyectos con compilación condicional, multi-targeting y compilaciones específicas de plataforma se benefician de la madurez del sistema de proyectos de Visual Studio Professional.
+- **Ingenieros de Bases de Datos** que trabajan con múltiples motores de bases de datos se benefician de DataGrip de maneras que ninguna extensión de VS Code iguala.
+- **Desarrolladores .NET en macOS o Linux** tienen exactamente una opción de IDE completo: JetBrains Rider.
+- **Ingenieros de Rendimiento** que investigan el comportamiento en tiempo de ejecución necesitan herramientas de perfilado que producen datos de la ejecución real, ya sea el perfilador integrado de Visual Studio, dotTrace o dotMemory.
+
+### Roles donde la licencia es más difícil de justificar
+
+- **Desarrolladores web y frontend** que trabajan en JavaScript, TypeScript o React. VS Code es el entorno nativo para este trabajo, y Copilot está mejor integrado aquí que en cualquier IDE completo.
+- **Desarrolladores Python** que hacen ML, ciencia de datos o scripting. VS Code con Jupyter y Copilot cubre el flujo de trabajo.
+- **Ingenieros DevOps y de Plataforma** que trabajan con YAML, Terraform, scripts de shell e infraestructura como código. Las extensiones de VS Code manejan esto de forma nativa.
+- **Desarrolladores estándar de APIs .NET** que no usan funciones exclusivas de Enterprise o específicas de Professional. VS Code con C# Dev Kit y Copilot es una alternativa seria.
+- **Desarrolladores full-stack** que trabajan en múltiples lenguajes. La amplitud del ecosistema de extensiones de VS Code supera la profundidad de cualquier IDE de un solo lenguaje.
+
+---
+
+## Cinco preguntas que hacer antes de renovar
+
+Si tu equipo está evaluando presupuestos de herramientas, estas preguntas cortan a través del ruido:
+
+1. **¿Qué funciones exclusivas del IDE alguien del equipo realmente usa semanalmente?** Live Unit Testing, IntelliTrace, diagramas de capas de arquitectura, diseñadores XAML, gestión de soluciones complejas. Si nadie las usa regularmente, la licencia está pagando por capacidades que existen solo en papel.
+
+2. **¿Qué porcentaje de tu flujo de trabajo de desarrollo ahora es impulsado por agentes de IA?** Si la mayoría de la generación de código, refactorización y testing es manejada por Copilot o herramientas similares, el valor marginal de las versiones nativas del IDE de esas funciones se acerca a cero.
+
+3. **¿Estás contabilizando el valor completo de la suscripción?** Créditos de Azure, precios dev/test, licencias de software de servidor y beneficios de capacitación son parte de la suscripción de Visual Studio. La comparación de presupuesto debe ser contra el paquete total, no solo el editor.
+
+4. **¿Tienen necesidades de depuración de producción que requieran instrumentación en tiempo de ejecución?** Snapshot Debugger, IntelliTrace y herramientas de perfilado resuelven problemas que ninguna IA puede abordar. Si tu equipo investiga regularmente problemas de producción en aplicaciones .NET, estas herramientas se pagan solas.
+
+5. **¿En qué plataformas trabajan tus desarrolladores?** Visual Studio es solo para Windows. Si tu equipo es multiplataforma, JetBrains Rider es la única opción de IDE .NET completo. Si todos están en Windows y construyen principalmente servicios web, VS Code con Copilot es una herramienta primaria legítima.
+
+---
+
+## ¿Hacia dónde va esto?
+
+La trayectoria es clara, aunque el cronograma no lo sea. Los agentes de IA seguirán mejorando en generación de código, refactorización, testing e incluso razonamiento arquitectónico. El conjunto de funciones que los IDEs completos pueden reclamar como exclusivamente suyas seguirá reduciéndose.
+
+Pero esa reducción tiene un piso. La instrumentación en tiempo de ejecución, el perfilado de producción, la aplicación de dependencias en vivo, los diseñadores visuales y la inteligencia profunda de bases de datos no son problemas de generación de código. Son problemas de observación, restricción y superficie de diseño que requieren acceso a sistemas en ejecución, pipelines de compilación, trazas de ejecución y motores de renderizado. Los modelos de IA no tienen ese acceso hoy, y ganarlo requeriría cambios arquitectónicos que van más allá de mejorar los modelos mismos.
+
+La posición honesta es esta: los IDEs completos ya no son la opción predeterminada para la mayoría de los desarrolladores. Son la opción especializada para roles específicos, problemas específicos y etapas específicas de madurez del software. Eso no es una disminución. Es una clarificación. Las mejores herramientas en software siempre han sido las que resuelven un problema específico mejor que cualquier otra cosa, y las funciones de IDE que sobreviven a la era de la IA son precisamente las que cumplen ese estándar.
+
+Los desarrolladores y equipos que aciertan en esto no elegirán una sola herramienta y se comprometerán con ella como una identidad. Construirán una cadena de herramientas que se ajuste a su trabajo real: VS Code y Copilot para el flujo de trabajo diario donde la edición AI-first es más rápida, y un IDE completo para los momentos donde la profundidad en tiempo de ejecución, la aplicación arquitectónica o la precisión de la superficie de diseño marca la diferencia entre depurar durante veinte minutos y depurar durante dos días.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
@@ -1,0 +1,182 @@
+---
+title: "Os IDEs completos ainda merecem um lugar na mesa na era da IA?"
+description: "Uma análise honesta de quando Visual Studio, JetBrains e outros IDEs completos ainda justificam seu custo de licença, e quando VS Code com agentes de IA genuinamente os tornou desnecessários. Uma análise por função para equipes que avaliam orçamentos de ferramentas em 2026."
+slug: full-ides-ai-era
+authors: [dsanchezcr]
+tags: [Developer Tools, AI, GitHub Copilot, Visual Studio, JetBrains, Software Engineering, Productivity]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-19-idesintheaiera/ides-ai-era.jpg
+date: 2026-04-19T10:00
+---
+
+# Os IDEs completos ainda merecem um lugar na mesa na era da IA?
+
+Um amigo meu cancelou sua assinatura do Visual Studio Enterprise em janeiro. Ele tinha usado por anos, construiu múltiplos sistemas .NET de produção nele, e genuinamente valorizava as ferramentas. Mas ele tinha passado os últimos seis meses fazendo quase toda a sua programação dentro do VS Code com GitHub Copilot Agent Mode, e não conseguia justificar a renovação.
+
+Três semanas depois, um serviço em segundo plano em produção começou a vazar memória. Ele tentou tudo na sua configuração do VS Code: logging, analisadores de diagnóstico, dumps de heap pela CLI. Nada dava uma imagem clara. Ele reinstalou sua licença Enterprise, abriu o Performance Profiler com .NET Object Allocation Tracking, identificou o vazamento em vinte minutos e corrigiu em dez. Depois voltou ao VS Code para todo o resto.
+
+Essa história é a versão honesta da questão sobre IDEs em 2026. Não se os IDEs completos estão mortos, nem se continuam sendo o padrão. A pergunta real é mais precisa: para quais funções, quais tarefas e quais bases de código eles ainda fornecem capacidades que editores potencializados por IA não conseguem replicar? E quando você olha o panorama completo, incluindo o que vem junto com uma assinatura do Visual Studio além do IDE em si, a análise é mais matizada do que qualquer lado do debate costuma admitir.
+
+{/* truncate */}
+
+![Os IDEs completos ainda merecem um lugar na mesa na era da IA?](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-04-19-idesintheaiera/ides-ai-era.jpg)
+
+---
+
+## O que os agentes de IA genuinamente resolveram
+
+Antes de apresentar o caso a favor dos IDEs, quero ser honesto sobre o que eles perderam.
+
+[A Pesquisa de Desenvolvedores do Stack Overflow 2025](https://survey.stackoverflow.co/2025) descobriu que 85% dos desenvolvedores agora usam ferramentas de IA regularmente, e a maioria relata usar duas ou três ferramentas complementares em vez de uma única vencedora. Isso não é uma curva de adoção marginal. É uma mudança de comportamento padrão.
+
+Aqui está o que os agentes de IA e editores aumentados por IA efetivamente comoditizaram:
+
+- **Autocompletar de código e IntelliSense.** As sugestões inline do Copilot superam rotineiramente o autocompletar clássico dos IDEs, especialmente para trabalho em múltiplas linguagens e APIs desconhecidas. A vantagem que Visual Studio e IntelliJ tinham aqui funcionalmente desapareceu.
+- **Scaffolding de código repetitivo.** Templates de projetos e assistentes dos IDEs eram úteis ao iniciar um novo serviço ou módulo. Agentes de IA geram scaffolding contextualizado mais rápido, com menos suposições incorporadas.
+- **Refatoração de múltiplos arquivos.** Testes independentes mostraram que o Cursor Pro completa refatorações de múltiplos arquivos aproximadamente 30% mais rápido que o Copilot em tarefas comparáveis. Ambos funcionam dentro do VS Code. Nenhum requer um IDE completo.
+- **Geração de testes.** Copilot e Claude conseguem gerar suites de testes abrangentes a partir do contexto. Isso costumava ser um ponto de venda para as ferramentas de testing dos IDEs.
+- **Diagnóstico de erros e sugestões de correção.** O modo agente no Copilot consegue identificar erros de compilação, propor correções, aplicá-las e reexecutar a compilação de forma autônoma. O menu de correção rápida parece antiquado em comparação.
+- **Documentação e explicação.** Interfaces baseadas em chat explicam código, geram documentação e respondem perguntas de arquitetura melhor do que qualquer visualizador de documentação integrado em um IDE.
+
+O IntelliTest, o recurso de geração automatizada de testes exclusivo do Visual Studio Enterprise, [foi descontinuado no VS 2026](https://learn.microsoft.com/visualstudio/test/intellitest-manual). É um sinal revelador. Quando a IA gera testes melhores a partir de prompts em linguagem natural do que um recurso de IDE projetado especificamente faz a partir da análise de código, o recurso perde sua razão de existir.
+
+As funcionalidades que justificavam uma licença básica de IDE para a maioria dos desenvolvedores há cinco anos foram absorvidas por ferramentas disponíveis em um editor gratuito. Esse é o ponto de partida desconfortável desta análise.
+
+---
+
+## Visual Studio Enterprise: o que a IA não consegue replicar
+
+As funcionalidades que permanecem exclusivas do Visual Studio Enterprise não são caixas de seleção de marketing. São ferramentas de instrumentação em tempo de execução, análise estática e aplicação de arquitetura que operam em camadas que a IA não alcançou. Entendê-las requer conectar cada uma ao problema concreto que resolve.
+
+### Live Unit Testing
+
+O Visual Studio Enterprise executa os testes afetados automaticamente enquanto você digita e mostra o status de aprovado/reprovado inline na margem do editor. Não depois de salvar. Não depois de executar um comando. Enquanto você digita. Ferramentas de IA podem gerar testes. Elas não conseguem executá-los de forma reativa e exibir feedback de cobertura em tempo real integrado à experiência de edição. Para engenheiros de QA e desenvolvedores seniores de .NET que mantêm grandes suites de testes, isso não é uma conveniência. É um ciclo de feedback fundamentalmente diferente que detecta regressões antes mesmo de você terminar de escrever a mudança que as causou.
+
+### IntelliTrace e depuração de viagem no tempo
+
+O IntelliTrace registra o histórico de execução e permite que você retroceda passo a passo através dele. Quando um processo de produção falha e você precisa entender a sequência de eventos que levou à falha, nenhuma quantidade de análise gerada por IA substitui a reprodução do rastro de execução real. LLMs podem hipotetizar sobre o que deu errado com base em padrões de código e logs. O IntelliTrace mostra o que realmente aconteceu. Para equipes que depuram sistemas distribuídos complexos, a diferença entre uma hipótese e uma gravação é a diferença entre horas de suposições e minutos de certeza.
+
+### Diagramas de camadas de arquitetura e validação de dependências
+
+O Visual Studio Enterprise pode aplicar regras de arquitetura em tempo de compilação. Você define quais camadas têm permissão para referenciar quais outras camadas, e a compilação falha se um desenvolvedor, ou um agente, introduzir uma dependência proibida. A IA pode descrever a arquitetura em prosa. Pode até desenhar diagramas. Mas não pode aplicar restrições de dependência no seu pipeline de compilação. Para arquitetos que mantêm a integridade estrutural de grandes soluções .NET com dezenas de projetos, isso não é um luxo. É o único mecanismo automatizado que previne a deriva arquitetônica em cada compilação.
+
+### Snapshot Debugger
+
+Para equipes que executam aplicações .NET no Azure, o Snapshot Debugger captura instantâneos de produção não intrusivos em linhas de código específicas sem parar o processo ou degradar o desempenho. Isso é instrumentação em tempo de execução, não inteligência de código. Quando você precisa entender o que está acontecendo em um serviço de produção que só se comporta mal sob padrões de tráfego real, sem anexar um depurador completo ou reimplantar com logging adicional, nenhuma ferramenta de IA fornece um equivalente. Os dados vêm do processo em execução, não da inferência de um modelo sobre o código.
+
+### Detecção de clones de código e Microsoft Fakes
+
+A Detecção de Clones de Código realiza análise semântica de lógica duplicada em toda a base de código, identificando duplicação que a busca simples de texto não encontra porque as implementações diferem sintaticamente mas realizam a mesma operação. A IA pode encontrar duplicação se você pedir para inspecionar arquivos específicos, mas o Visual Studio faz isso passivamente através de milhões de linhas como parte de sua análise contínua. O Microsoft Fakes fornece frameworks de shim e stub que isolam testes unitários de dependências externas no nível do CLR, e a Análise de Impacto de Testes identifica quais testes precisam ser executados com base em qual código mudou. Nenhuma ferramenta de IA fornece análise de impacto de testes no nível de tempo de execução.
+
+---
+
+## Visual Studio Professional: o nível intermediário sob pressão
+
+O Visual Studio Professional está em uma posição mais disputada em 2026, mas ainda tem um caso concreto para cenários específicos. Seu valor não é mais sobre IntelliSense ou refatoração, onde VS Code com Copilot se equiparou. É sobre o sistema de projetos, a integração de compilação e as ferramentas de design que VS Code ainda não iguala.
+
+### Onde Professional ainda justifica seu custo
+
+- **Desenvolvimento de desktop Windows.** Os designers visuais de WPF, WinForms e MAUI permanecem exclusivos do Visual Studio. Se sua equipe constrói aplicações de desktop Windows, não há equivalente no VS Code para design de formulários arrastar-e-soltar, visualização prévia de XAML ou a experiência de MAUI Hot Reload. Essa não é uma diferença marginal. É a presença ou ausência de um fluxo de trabalho de desenvolvimento inteiro.
+- **MSBuild e gestão de soluções complexas.** O C# Dev Kit do VS Code lida bem com projetos individuais e soluções com poucos projetos. Mas para soluções com 20, 50 ou mais de 100 projetos, com ordenamento de compilação complexo, compilação condicional e targeting de plataformas, o sistema de projetos do Visual Studio e o Solution Explorer são materialmente melhores para gerenciar a complexidade. Configuração de compilação entre perfis Debug/Release/personalizados, gerenciamento de pacotes NuGet com resolução visual de conflitos e multi-targeting (.NET Framework + .NET 9 na mesma solução) são áreas onde a maturidade do IDE se mostra.
+- **Profiling e diagnósticos integrados.** Embora as ferramentas de profiling mais profundas pertençam ao nível Enterprise ou a terceiros, o Visual Studio Professional inclui o Performance Profiler integrado com análise de uso de CPU, alocação de memória e alocação de objetos .NET. São mais leves que as ferramentas de nível Enterprise, mas significativamente mais integrados do que qualquer coisa disponível no VS Code.
+- **Ferramentas de integração com Azure.** Connected Services, provisionamento de recursos na nuvem e o fluxo de trabalho de publicação no Azure são mais integrados no Visual Studio Professional do que em qualquer extensão do VS Code. Para equipes que implantam no Azure App Service, Azure Functions ou Azure Container Apps, o assistente de publicação e os perfis de implantação reduzem a fricção comparado com fluxos de trabalho apenas de CLI.
+- **CodeLens.** Referências inline, status de testes e informações de Git blame exibidos diretamente no editor para cada método e classe. VS Code tem extensões que aproximam isso, mas a implementação do Visual Studio é mais profunda e confiável em soluções grandes.
+
+### A avaliação honesta
+
+Para desenvolvedores .NET que constroem APIs web e microsserviços, que estão confortáveis com o terminal e já usam Copilot, VS Code com C# Dev Kit é uma alternativa legítima ao Professional. A lacuna diminuiu consideravelmente. Mas para equipes que constroem aplicações de desktop, gerenciam soluções complexas com múltiplos projetos ou dependem de designers visuais, Professional continua sendo a ferramenta certa, não por tradição, mas porque as capacidades específicas não têm equivalente em outro lugar.
+
+---
+
+## A assinatura do Visual Studio: além do IDE
+
+Uma dimensão que comparações puras de IDE-vs-editor consistentemente ignoram é o que vem junto com uma assinatura do Visual Studio. A licença não é apenas uma licença de IDE. É uma assinatura que inclui recursos de desenvolvimento e teste que afetam o custo total das operações de engenharia.
+
+### O que a assinatura inclui
+
+- **Créditos mensais de Azure.** Assinantes do Visual Studio Professional recebem $50/mês em créditos de Azure. Assinantes Enterprise recebem $150/mês. Para desenvolvedores individuais ou equipes pequenas, esses créditos podem cobrir ambientes de desenvolvimento e teste, computação de pipelines de CI/CD ou implantações sandbox inteiramente. São $600 a $1.800 por ano em gastos com Azure que já estão incluídos no custo da assinatura.
+- **Preços Azure Dev/Test.** Assinantes obtêm tarifas com desconto em serviços Azure especificamente para cargas de trabalho de desenvolvimento e teste. Máquinas Virtuais Windows, por exemplo, são cobradas a tarifas de Linux sem cobrança adicional pela licença do Windows. Para equipes que executam ambientes de teste, ambientes de staging ou infraestrutura de testes de carga no Azure, as economias se acumulam.
+- **Acesso ao catálogo completo de software Microsoft para dev/test.** As assinaturas do Visual Studio incluem licenças de Windows Server, SQL Server e outros softwares de servidor Microsoft para fins de desenvolvimento e teste. Equipes que de outra forma precisariam de licenças separadas para ambientes de teste evitam esse custo completamente.
+- **Pluralsight, LinkedIn Learning e benefícios de treinamento.** Assinaturas Enterprise incluem acesso a plataformas de treinamento. Se são usadas ou não depende da cultura de aprendizado da equipe, mas representam valor real como item de orçamento que compensa o custo da assinatura.
+- **Azure DevOps.** Assinantes do Visual Studio obtêm recursos aprimorados do Azure DevOps, incluindo uma licença Basic + Test Plans. Para equipes que já usam Azure DevOps para rastreamento de trabalho e CI/CD, isso elimina um custo separado por usuário.
+- **Incidentes de suporte técnico.** Professional inclui dois e Enterprise inclui quatro incidentes de suporte consultivo por ano com a Microsoft. Não são ilimitados, mas um único incidente de suporte bem cronometrado em um problema que bloqueia a produção pode recuperar o custo de toda a assinatura anual.
+
+---
+
+## JetBrains: o caso multiplataforma e de especialização por linguagem
+
+Os IDEs do JetBrains merecem atenção específica não como concorrentes do Visual Studio no espaço .NET, mas como especialistas em áreas onde não têm equivalente.
+
+### Onde JetBrains se diferencia
+
+- **Rider para .NET no macOS e Linux.** O Visual Studio Enterprise é apenas para Windows. Para equipes .NET onde desenvolvedores usam macOS ou Linux, o JetBrains Rider é a única opção de IDE completo. Também inclui dotTrace e dotMemory para profiling de desempenho e memória, capacidades que são exclusivas do Enterprise ou de terceiros no ecossistema do Visual Studio.
+- **DataGrip para trabalho com múltiplos bancos de dados.** O DataGrip fornece navegação com conhecimento de schema, execução de consultas, edição de dados e diagramas ER através de PostgreSQL, MongoDB, Redis, BigQuery e dezenas de outros bancos de dados em um espaço de trabalho unificado. Nenhuma extensão do VS Code fornece a mesma profundidade de compreensão de schema, capacidades de consulta entre bancos de dados ou exploração de dados ao vivo. Para engenheiros de bancos de dados e desenvolvedores backend que trabalham com múltiplos motores de banco de dados diariamente, o DataGrip preenche uma lacuna que nem o Visual Studio nem o VS Code cobrem bem.
+- **Profundidade específica por linguagem.** IntelliJ IDEA para Java/Kotlin, PyCharm para Python, GoLand para Go e PhpStorm para PHP fornecem modelos semânticos construídos especificamente para sua linguagem. Inferência de tipos, análise de fluxo e inspeções específicas de framework operam a uma profundidade que extensões de propósito geral não conseguem igualar completamente.
+
+### IA dentro do IDE
+
+O JetBrains agora tem o Claude Agent nativamente integrado junto com o Junie em uma experiência multi-agente dentro do IDE. Os agentes de IA operam dentro do modelo semântico do IDE, compartilhando a mesma compreensão da árvore de sintaxe abstrata que impulsiona o motor de refatoração. Isso é arquitetonicamente diferente do VS Code, onde agentes de IA trabalham principalmente a partir de texto e embeddings. O efeito prático é que a refatoração assistida por IA dentro de um IDE JetBrains produz resultados mais estruturalmente precisos em bases de código grandes.
+
+---
+
+## O argumento contraintuitivo: a IA torna ambientes de ferramentas ricos mais valiosos, não menos
+
+A narrativa "os IDEs estão mortos" ignora um ponto estrutural. Agentes de IA são mais poderosos quando têm um ambiente de ferramentas rico para trabalhar. Um agente que opera dentro do modelo semântico do Visual Studio ou do Rider, com acesso ao mesmo sistema de tipos, grafo de dependências e contexto de compilação que o IDE usa para sua própria refatoração, produz resultados de maior qualidade do que um agente trabalhando apenas a partir de texto.
+
+Para projetos simples em uma única linguagem, VS Code fornece contexto suficiente para agentes de IA trabalharem efetivamente. Para grandes soluções .NET, aplicações Java com múltiplos projetos ou bases de código com restrições arquitetônicas rigorosas, a profundidade semântica do IDE não é sobrecarga. É a base que torna a camada de IA mais precisa.
+
+A implicação vale a pena ser declarada claramente: agentes de IA não tornam ambientes semânticos ricos menos valiosos. Eles os tornam mais valiosos, porque a qualidade da saída do agente é proporcional à profundidade do contexto em que opera.
+
+---
+
+## A análise por função
+
+Nem todo desenvolvedor precisa das mesmas ferramentas, e fingir o contrário leva a orçamentos desperdiçados em ambas as direções: pagando por funcionalidades que ninguém usa, ou economizando em licenças apenas para perder horas quando uma capacidade específica é necessária.
+
+### Funções onde os IDEs completos ainda justificam seu custo
+
+- **Arquitetos de Software** que mantêm grandes soluções .NET precisam de validação de dependências e aplicação de camadas de arquitetura no nível de compilação. Nenhuma ferramenta de IA replica isso.
+- **Engenheiros de QA e Testing** em projetos .NET se beneficiam mensuravelmente do Live Unit Testing, IntelliTrace e Microsoft Fakes. São funcionalidades de uso diário, não conveniências ocasionais.
+- **Equipes de SRE e Plataforma** que executam aplicações .NET hospedadas no Azure precisam do Snapshot Debugger para diagnósticos de produção que não podem ser reproduzidos localmente.
+- **Desenvolvedores de desktop Windows** que constroem aplicações WPF, WinForms ou MAUI dependem das ferramentas de design do Visual Studio, que não têm equivalente no VS Code.
+- **Equipes .NET com soluções complexas** que gerenciam mais de 20 projetos com compilação condicional, multi-targeting e compilações específicas de plataforma se beneficiam da maturidade do sistema de projetos do Visual Studio Professional.
+- **Engenheiros de Bancos de Dados** que trabalham com múltiplos motores de banco de dados se beneficiam do DataGrip de maneiras que nenhuma extensão do VS Code iguala.
+- **Desenvolvedores .NET no macOS ou Linux** têm exatamente uma opção de IDE completo: JetBrains Rider.
+- **Engenheiros de Performance** que investigam comportamento em tempo de execução precisam de ferramentas de profiling que produzem dados da execução real, seja o profiler integrado do Visual Studio, dotTrace ou dotMemory.
+
+### Funções onde a licença é mais difícil de justificar
+
+- **Desenvolvedores web e frontend** que trabalham em JavaScript, TypeScript ou React. VS Code é o ambiente nativo para esse trabalho, e o Copilot está melhor integrado aqui do que em qualquer IDE completo.
+- **Desenvolvedores Python** que fazem ML, ciência de dados ou scripting. VS Code com Jupyter e Copilot cobre o fluxo de trabalho.
+- **Engenheiros DevOps e de Plataforma** que trabalham com YAML, Terraform, scripts shell e infraestrutura como código. Extensões do VS Code lidam com isso nativamente.
+- **Desenvolvedores padrão de APIs .NET** que não usam funcionalidades exclusivas do Enterprise ou específicas do Professional. VS Code com C# Dev Kit e Copilot é uma alternativa séria.
+- **Desenvolvedores full-stack** que trabalham em várias linguagens. A amplitude do ecossistema de extensões do VS Code supera a profundidade de qualquer IDE de linguagem única.
+
+---
+
+## Cinco perguntas para fazer antes de renovar
+
+Se sua equipe está avaliando orçamentos de ferramentas, estas perguntas cortam o ruído:
+
+1. **Quais funcionalidades exclusivas do IDE alguém da equipe realmente usa semanalmente?** Live Unit Testing, IntelliTrace, diagramas de camadas de arquitetura, designers XAML, gestão de soluções complexas. Se ninguém as usa regularmente, a licença está pagando por capacidades que existem apenas no papel.
+
+2. **Qual porcentagem do seu fluxo de trabalho de desenvolvimento agora é impulsionada por agentes de IA?** Se a maioria da geração de código, refatoração e testing é gerenciada pelo Copilot ou ferramentas similares, o valor marginal das versões nativas do IDE dessas funcionalidades se aproxima de zero.
+
+3. **Vocês estão contabilizando o valor completo da assinatura?** Créditos de Azure, preços dev/test, licenças de software de servidor e benefícios de treinamento fazem parte da assinatura do Visual Studio. A comparação de orçamento deve ser contra o pacote total, não apenas o editor.
+
+4. **Vocês têm necessidades de depuração de produção que requerem instrumentação em tempo de execução?** Snapshot Debugger, IntelliTrace e ferramentas de profiling resolvem problemas que nenhuma IA pode abordar. Se sua equipe investiga regularmente problemas de produção em aplicações .NET, essas ferramentas se pagam sozinhas.
+
+5. **Em quais plataformas seus desenvolvedores trabalham?** Visual Studio é apenas para Windows. Se sua equipe é multiplataforma, o JetBrains Rider é a única opção de IDE .NET completo. Se todos estão no Windows e constroem principalmente serviços web, VS Code com Copilot é uma ferramenta primária legítima.
+
+---
+
+## Para onde isso vai?
+
+A trajetória é clara, mesmo que o cronograma não seja. Os agentes de IA continuarão melhorando na geração de código, refatoração, testing e até raciocínio arquitetônico. O conjunto de funcionalidades que os IDEs completos podem reivindicar como exclusivamente suas continuará a diminuir.
+
+Mas essa diminuição tem um piso. Instrumentação em tempo de execução, profiling de produção, aplicação de dependências ao vivo, designers visuais e inteligência profunda de bancos de dados não são problemas de geração de código. São problemas de observação, restrição e superfície de design que requerem acesso a sistemas em execução, pipelines de compilação, rastros de execução e motores de renderização. Os modelos de IA não têm esse acesso hoje, e obtê-lo exigiria mudanças arquitetônicas que vão além de melhorar os próprios modelos.
+
+A posição honesta é esta: os IDEs completos não são mais a escolha padrão para a maioria dos desenvolvedores. São a escolha especializada para funções específicas, problemas específicos e estágios específicos de maturidade do software. Isso não é uma diminuição. É uma clarificação. As melhores ferramentas em software sempre foram as que resolvem um problema específico melhor do que qualquer outra coisa, e as funcionalidades de IDE que sobrevivem à era da IA são precisamente as que atendem a esse padrão.
+
+Os desenvolvedores e equipes que acertarem isso não vão escolher uma ferramenta e se comprometer com ela como uma identidade. Vão construir uma cadeia de ferramentas que corresponda ao seu trabalho real: VS Code e Copilot para o fluxo de trabalho diário onde a edição AI-first é mais rápida, e um IDE completo para os momentos onde a profundidade em tempo de execução, a aplicação de arquitetura ou a precisão da superfície de design faz a diferença entre depurar por vinte minutos e depurar por dois dias.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-04-19-IDEsInTheAIEra.mdx
@@ -155,21 +155,6 @@ Nem todo desenvolvedor precisa das mesmas ferramentas, e fingir o contrário lev
 
 ---
 
-## Cinco perguntas para fazer antes de renovar
-
-Se sua equipe está avaliando orçamentos de ferramentas, estas perguntas cortam o ruído:
-
-1. **Quais funcionalidades exclusivas do IDE alguém da equipe realmente usa semanalmente?** Live Unit Testing, IntelliTrace, diagramas de camadas de arquitetura, designers XAML, gestão de soluções complexas. Se ninguém as usa regularmente, a licença está pagando por capacidades que existem apenas no papel.
-
-2. **Qual porcentagem do seu fluxo de trabalho de desenvolvimento agora é impulsionada por agentes de IA?** Se a maioria da geração de código, refatoração e testing é gerenciada pelo Copilot ou ferramentas similares, o valor marginal das versões nativas do IDE dessas funcionalidades se aproxima de zero.
-
-3. **Vocês estão contabilizando o valor completo da assinatura?** Créditos de Azure, preços dev/test, licenças de software de servidor e benefícios de treinamento fazem parte da assinatura do Visual Studio. A comparação de orçamento deve ser contra o pacote total, não apenas o editor.
-
-4. **Vocês têm necessidades de depuração de produção que requerem instrumentação em tempo de execução?** Snapshot Debugger, IntelliTrace e ferramentas de profiling resolvem problemas que nenhuma IA pode abordar. Se sua equipe investiga regularmente problemas de produção em aplicações .NET, essas ferramentas se pagam sozinhas.
-
-5. **Em quais plataformas seus desenvolvedores trabalham?** Visual Studio é apenas para Windows. Se sua equipe é multiplataforma, o JetBrains Rider é a única opção de IDE .NET completo. Se todos estão no Windows e constroem principalmente serviços web, VS Code com Copilot é uma ferramenta primária legítima.
-
----
 
 ## Para onde isso vai?
 


### PR DESCRIPTION
Add new blog post "Do full IDEs still deserve a seat at the table in the AI era?" and localized Spanish and Portuguese versions. Adds English source at blog/2026-04-19-IDEsInTheAIEra.mdx and translations at i18n/es/... and i18n/pt/..., including frontmatter (title, description, authors, tags, image, date) and full article content analyzing IDE vs AI-agent tooling and role-based guidance for 2026.