### PR TITLE
Add guide: Building mobile apps in agentic era

### DIFF
--- a/blog/2026-05-18-BuildingMobileAppsAgenticEra.mdx
+++ b/blog/2026-05-18-BuildingMobileAppsAgenticEra.mdx
@@ -1,0 +1,205 @@
+---
+title: "Building mobile and device apps in the agentic era: a practical guide to native, MAUI, React Native, and more"
+description: "A 2026 guide to building apps for iOS, Android, Windows, and Xbox: the realistic options, the pros and cons of each, and how AI agents are reshaping the way developers learn and work across frameworks."
+slug: building-mobile-apps-agentic-era
+authors: [dsanchezcr]
+tags: [Mobile Development, Native Apps, AI, Agentic AI, .NET MAUI, React Native, Flutter, Kotlin Multiplatform, SwiftUI, Jetpack Compose, WinUI, GitHub Copilot, Software Engineering]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-05-18-buildingmobileappsagenticera/building-mobile-apps-agentic-era.jpg
+date: 2026-05-18T10:00
+---
+
+# Building mobile and device apps in the agentic era: a practical guide to native, MAUI, React Native, and more
+
+Choosing how to build a mobile or device app used to be a contained decision. Pick the platforms, weigh native against cross-platform, factor in team skills, and choose a framework. The trade-offs were mostly about runtime performance, hiring, and how much code you could realistically share.
+
+Two things have shifted that picture. First, the platform landscape itself has matured: SwiftUI, Jetpack Compose, WinUI 3, .NET MAUI, React Native's New Architecture, Flutter with Impeller, and Kotlin Multiplatform have all reached a level of stability that makes a clean comparison possible. Second, AI agents are now part of the daily loop for most teams. They do not just complete code; they read repositories, summarize unfamiliar APIs, generate scaffolding, and shorten the path from "I have never used this framework" to "I shipped something with it." That changes how the framework decision should be made.
+
+This guide walks through the realistic options for iOS, Android, Windows, and Xbox, the main cross-platform frameworks, and the pros and cons of each in 2026.
+
+{/* truncate */}
+
+![Building mobile and device apps in the agentic era](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-05-18-buildingmobileappsagenticera/building-mobile-apps-agentic-era.jpg)
+
+---
+
+## How AI agents changed the framework decision
+
+The old framework debate weighted ecosystem familiarity heavily, because the learning curve was real. Picking a stack the team did not already know meant weeks of ramp-up: reading docs, watching talks, building toy apps, and slowly internalizing patterns before any production work could start.
+
+Agents have not eliminated that curve, but they have flattened it. A developer who has never touched Jetpack Compose, SwiftUI, or Flutter can sit down with an agent and produce a working screen in an afternoon. More importantly, agents can read an existing codebase and explain it. A senior engineer joining an unfamiliar React Native or MAUI project can ask the agent to map the architecture, summarize the navigation graph, or trace how a network call flows from a button tap to the API layer. Onboarding that used to take a sprint now takes a day.
+
+This has two practical consequences for the framework decision:
+
+- **Team familiarity matters less than it used to.** It is still a factor, but the gap between "the language we know" and "the language we do not" has narrowed significantly. Picking the right tool for the product is now more affordable than picking the tool the team already happens to know.
+- **The size and quality of a framework's public corpus matters more.** Agents are stronger in stacks with a lot of public code and documentation, because that is what they were trained on. JavaScript and TypeScript sit at the top. Kotlin and Swift are solid. Dart is smaller but consistent. C# is well represented in general, with platform-specific dialects like MAUI's XAML being thinner but improving.
+
+With that lens, here are the realistic options.
+
+---
+
+## Native iOS: Swift and SwiftUI
+
+Swift with SwiftUI is Apple's recommended path for new iOS and iPadOS apps. UIKit remains the right call when you need deep platform integration or are extending a mature codebase.
+
+**Pros**
+
+- The strongest possible iOS experience: native performance, full access to platform APIs (CoreML, ARKit, WidgetKit, App Intents), and tight integration with the Apple ecosystem.
+- SwiftUI has a dense public corpus by now, so agents produce reliable scaffolding for screens, navigation, and state.
+- Swift Package Manager and command-line tooling have matured, so agent-driven loops no longer require living inside Xcode for every step.
+
+**Cons**
+
+- macOS is required for builds, and code signing and provisioning remain friction points.
+- iOS-only means a second team or framework for Android.
+- Performance tuning, ARKit work, and platform-specific edge cases still benefit from senior engineering judgment more than agent output.
+
+Best fit: products where iOS is the primary or only target and the experience needs to feel fully native.
+
+---
+
+## Native Android: Kotlin and Jetpack Compose
+
+Kotlin with [Jetpack Compose](https://developer.android.com/compose) is Google's recommended path. The older XML View system is still supported for legacy work.
+
+**Pros**
+
+- Kotlin is one of the cleaner languages in modern training data, and Compose's declarative model maps well to how agents decompose UI.
+- The entire toolchain, from Gradle to the emulator to `adb`, is scriptable from a terminal. Agents can install builds, capture logcat, and drive emulators end-to-end. This makes Android the most agent-friendly mobile platform today.
+- Full access to platform APIs and a strong Google-backed ecosystem.
+
+**Cons**
+
+- Android-only means a second framework or team for iOS.
+- The long tail of OEM differences, foreground service rules, and edge-to-edge UI requirements still requires human judgment.
+- Compose performance tuning on complex screens is not a place to rely on agent output alone.
+
+Best fit: products where Android is the primary target, or where you want one of the smoothest agent-assisted development experiences available.
+
+---
+
+## Windows: WinUI 3 and the Windows App SDK
+
+For new Windows desktop apps, [WinUI 3](https://learn.microsoft.com/windows/apps/winui/winui3/) on the [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/) is Microsoft's recommended stack. WPF and WinForms remain supported for existing apps and line-of-business work.
+
+**Pros**
+
+- Modern, native Windows experience with access to the latest platform features.
+- Integrates naturally with the broader .NET stack: ASP.NET Core backends, Azure SDKs, and Entity Framework.
+- A clear forward-looking direction for new desktop development.
+
+**Cons**
+
+- The WinUI 3 corpus is still growing, so agent suggestions are less mature here than for SwiftUI or Compose.
+- No single framework targets Windows desktop and Xbox from the same project today.
+
+For Xbox apps, UWP remains the path through the Microsoft Store today, and for games the [Microsoft Game Development Kit](https://learn.microsoft.com/gaming/gdk/) along with engines like Unreal and Unity is the realistic answer. If Xbox is on your roadmap, plan for it as a separate track rather than expecting a cross-platform framework to absorb it.
+
+Best fit: .NET teams building modern Windows desktop apps, especially when there is a shared backend or Blazor component story.
+
+---
+
+## .NET MAUI
+
+[.NET MAUI](https://learn.microsoft.com/dotnet/maui/) is the evolution of Xamarin.Forms. One C# and XAML codebase targets iOS, Android, macOS, and Windows. The [.NET MAUI roadmap](https://github.com/dotnet/maui/wiki/roadmap) is publicly maintained.
+
+**Pros**
+
+- One codebase across the four major targets for a .NET-native team.
+- Tight integration with ASP.NET Core, Entity Framework, Azure SDKs, and Blazor Hybrid for sharing UI between web and native.
+- Visual Studio tooling makes multi-device debugging straightforward, and hot reload is reliable.
+- Mature component vendors (Telerik, Syncfusion, DevExpress) ship full suites.
+- Microsoft has publicly named improving agent productivity on .NET and MAUI as an investment area, and the corpus is growing.
+
+**Cons**
+
+- Smaller training corpus than React Native or Flutter today, so agent suggestions in the XAML and handler layers can be less reliable than for more widely used UI frameworks.
+- Major .NET releases can bring platform-level UI changes that require stabilization work; staying one LTS release behind is a common pattern.
+- Animation-heavy consumer apps tend to fit Flutter or native better.
+
+Best fit: .NET teams building productivity, enterprise, or line-of-business apps across mobile and Windows, especially when the backend is already in .NET.
+
+---
+
+## React Native
+
+[React Native](https://reactnative.dev/) with the [New Architecture](https://reactnative.dev/architecture/landing-page) (Fabric, JSI, TurboModules, and Hermes as the default JavaScript engine) is what large teams at Meta, Microsoft, Shopify, and Discord use in production. [React Native for Windows and macOS](https://microsoft.github.io/react-native-windows/) is maintained by Microsoft.
+
+**Pros**
+
+- JavaScript and TypeScript sit on top of the densest public corpus of any language family, so agents produce strong suggestions across scaffolding, state, navigation, and API integration.
+- The npm ecosystem and [Expo](https://expo.dev/) remove most of the historical pain around native modules and build infrastructure. An agent can scaffold a project, build it, and ship a TestFlight or Play Store build with minimal human steps.
+- Renders with real platform UI components, so buttons and lists feel native on each platform.
+
+**Cons**
+
+- Animation-heavy interfaces can still drop frames under sustained load, although the New Architecture has narrowed the gap.
+- Native modules occasionally require platform expertise that JavaScript developers do not have.
+- "Native feel on each platform" is a feature for some products and a frustration for others when design teams want pixel-identical UI.
+
+Best fit: consumer mobile apps for iOS and Android where time to first build and agent productivity matter most.
+
+---
+
+## Flutter
+
+[Flutter](https://flutter.dev/) uses Dart and the Impeller rendering engine, which has replaced Skia on iOS and Android.
+
+**Pros**
+
+- The highest cross-platform visual consistency of any mainstream option, because Flutter draws every pixel itself rather than wrapping platform UI.
+- Excellent performance on animation-heavy and graphically rich interfaces.
+- Hot reload is fast, and the build system is scriptable.
+- Flutter's API surface is unusually consistent and well-documented, which makes it more agent-friendly than Dart's corpus size alone would suggest.
+
+**Cons**
+
+- Dart has a smaller community than JavaScript, which means a smaller hiring pool.
+- App size tends to be larger because Flutter ships its own rendering engine.
+- Web support has improved but is still weaker than dedicated web frameworks for SEO-critical sites.
+
+Best fit: products where the design must be pixel-identical across platforms, or where animations and custom graphics are central to the experience.
+
+---
+
+## Kotlin Multiplatform
+
+[Kotlin Multiplatform](https://www.jetbrains.com/kotlin-multiplatform/) (KMP) shares business logic across platforms in Kotlin while letting UIs stay fully native. [Compose Multiplatform for iOS reached stable in 2025](https://blog.jetbrains.com/kotlin/2025/05/compose-multiplatform-1-8-0-released-compose-multiplatform-for-ios-is-stable-and-production-ready/), so shared UI is also a viable option.
+
+**Pros**
+
+- Solves the part of cross-platform that hurts most: duplicated business logic, models, networking, validation, and persistence. The "shared core, native UI" pattern keeps SwiftUI on iOS and Jetpack Compose on Android while eliminating duplication underneath.
+- Kotlin has a solid training corpus, and the architectural separation between shared and platform-specific code is clear enough that agents follow it well.
+- Incremental adoption: you can introduce KMP into an existing native iOS and Android codebase one module at a time.
+
+**Cons**
+
+- Entry cost is higher for teams without existing native iOS and Android foundations.
+- Kotlin/Native interop with Swift can produce confusing agent output, especially around concurrency and the newer Swift export tooling.
+- Shared-UI through Compose Multiplatform is newer than the native paths and the iOS-specific ecosystem around it is still maturing.
+
+Best fit: teams that already have native iOS and Android engineers and feel the pain of maintaining the same business logic twice.
+
+---
+
+## A 2026 decision framework
+
+A short version that you can apply to most product decisions:
+
+- **Consumer mobile app for iOS and Android, maximum agent productivity:** React Native with Expo is the strongest default. Flutter is the alternative when pixel-identical UI is non-negotiable.
+- **.NET team building enterprise apps across mobile and Windows:** .NET MAUI is the right call. Plan Xbox as a separate track if it is in scope.
+- **Existing native iOS and Android teams with duplicated business logic:** Kotlin Multiplatform with native UIs is the most surgical fit.
+- **Single-platform experience that needs to go deep:** Stay native. SwiftUI on iOS or Jetpack Compose on Android, with agents accelerating everything that can be accelerated.
+- **Windows-first desktop app from a .NET team:** WinUI 3 on the Windows App SDK.
+- **Xbox apps:** Plan a dedicated UWP track or use a game engine for games.
+
+---
+
+## Closing thoughts
+
+Frameworks are no longer evaluated only on runtime characteristics. They are also evaluated on how well an AI agent can read, write, and reason about code in them. The frameworks doing best in 2026 are the ones where stability, public corpus, and scriptable tooling combine to let small teams move at the speed an agent-augmented workflow makes possible.
+
+The good news is that the cost of learning a new stack has dropped sharply. A team that would have hesitated to adopt Kotlin Multiplatform or Flutter two years ago because of the ramp-up can now seriously consider it, because the ramp-up itself is no longer the bottleneck it used to be. That changes which framework is the right answer for many products, and it is worth revisiting decisions made before agents were part of the loop.
+
+Pick the framework that fits the product, the platforms, and the team you actually have. The agent will help you get there faster than it used to.

--- a/i18n/es/docusaurus-plugin-content-blog/2026-05-18-BuildingMobileAppsAgenticEra.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-05-18-BuildingMobileAppsAgenticEra.mdx
@@ -1,0 +1,205 @@
+---
+title: "Crear apps móviles y de dispositivo en la era agéntica: una guía práctica de nativo, MAUI, React Native y más"
+description: "Una guía de 2026 para crear apps para iOS, Android, Windows y Xbox: las opciones realistas, los pros y contras de cada una y cómo los agentes de IA están cambiando la forma en que los desarrolladores aprenden y trabajan en distintos frameworks."
+slug: building-mobile-apps-agentic-era
+authors: [dsanchezcr]
+tags: [Mobile Development, Native Apps, AI, Agentic AI, .NET MAUI, React Native, Flutter, Kotlin Multiplatform, SwiftUI, Jetpack Compose, WinUI, GitHub Copilot, Software Engineering]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-05-18-buildingmobileappsagenticera/building-mobile-apps-agentic-era.jpg
+date: 2026-05-18T10:00
+---
+
+# Crear apps móviles y de dispositivo en la era agéntica: una guía práctica de nativo, MAUI, React Native y más
+
+Decidir cómo construir una app móvil o de dispositivo solía ser una decisión acotada. Elegir las plataformas, sopesar nativo contra multiplataforma, considerar las habilidades del equipo y escoger un framework. Las compensaciones eran sobre todo de rendimiento en tiempo de ejecución, contratación y cuánto código se podía compartir de verdad.
+
+Dos cosas han cambiado ese panorama. Primero, el panorama de plataformas ha madurado: SwiftUI, Jetpack Compose, WinUI 3, .NET MAUI, la New Architecture de React Native, Flutter con Impeller y Kotlin Multiplatform han alcanzado un nivel de estabilidad que permite una comparación limpia. Segundo, los agentes de IA ya forman parte del día a día de la mayoría de los equipos. No solo completan código; leen repositorios, resumen APIs desconocidas, generan andamiajes y acortan el camino entre "nunca he usado este framework" y "ya envié algo con él". Eso cambia la forma de tomar la decisión de framework.
+
+Esta guía recorre las opciones realistas para iOS, Android, Windows y Xbox, los principales frameworks multiplataforma y los pros y contras de cada uno en 2026.
+
+{/* truncate */}
+
+![Crear apps móviles y de dispositivo en la era agéntica](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-05-18-buildingmobileappsagenticera/building-mobile-apps-agentic-era.jpg)
+
+---
+
+## Cómo los agentes de IA cambiaron la decisión de framework
+
+El viejo debate sobre frameworks pesaba mucho la familiaridad del equipo, porque la curva de aprendizaje era real. Elegir un stack que el equipo no conocía implicaba semanas de rampa: leer documentación, ver charlas, construir apps de juguete e internalizar patrones poco a poco antes de poder empezar el trabajo de producción.
+
+Los agentes no han eliminado esa curva, pero la han aplanado. Un desarrollador que nunca ha tocado Jetpack Compose, SwiftUI o Flutter puede sentarse con un agente y producir una pantalla funcional en una tarde. Más importante todavía, los agentes pueden leer una base de código existente y explicarla. Una ingeniera senior que se incorpora a un proyecto desconocido en React Native o MAUI puede pedirle al agente que mapee la arquitectura, resuma el grafo de navegación o rastree cómo una llamada de red fluye desde un botón hasta la capa de API. La incorporación que antes tomaba un sprint hoy toma un día.
+
+Esto tiene dos consecuencias prácticas para la decisión de framework:
+
+- **La familiaridad del equipo importa menos que antes.** Sigue siendo un factor, pero la brecha entre "el lenguaje que conocemos" y "el que no" se ha reducido bastante. Elegir la herramienta adecuada para el producto es ahora más accesible que elegir la que el equipo ya conoce.
+- **El tamaño y la calidad del corpus público de un framework importan más.** Los agentes son más fuertes en stacks con mucho código y documentación pública, porque eso es con lo que fueron entrenados. JavaScript y TypeScript están en la cima. Kotlin y Swift son sólidos. Dart es más pequeño pero consistente. C# está bien representado en general, con dialectos específicos como el XAML de MAUI más delgados pero en crecimiento.
+
+Con esa lente, estas son las opciones realistas.
+
+---
+
+## iOS nativo: Swift y SwiftUI
+
+Swift con SwiftUI es el camino recomendado por Apple para nuevas apps de iOS y iPadOS. UIKit sigue siendo la opción correcta cuando se necesita integración profunda con la plataforma o se está extendiendo una base de código madura.
+
+**Pros**
+
+- La mejor experiencia posible en iOS: rendimiento nativo, acceso total a las APIs de la plataforma (CoreML, ARKit, WidgetKit, App Intents) e integración estrecha con el ecosistema Apple.
+- SwiftUI ya tiene un corpus público denso, así que los agentes producen andamiajes fiables para pantallas, navegación y estado.
+- Swift Package Manager y las herramientas de línea de comandos han madurado, así que los bucles guiados por agente ya no requieren vivir dentro de Xcode en cada paso.
+
+**Contras**
+
+- macOS es obligatorio para compilar, y la firma y aprovisionamiento siguen siendo puntos de fricción.
+- Solo iOS implica un segundo equipo o framework para Android.
+- El tuning de rendimiento, el trabajo con ARKit y los casos límite específicos de la plataforma siguen beneficiándose más del juicio de ingeniería senior que de la salida del agente.
+
+Mejor encaje: productos donde iOS es el objetivo principal o único y la experiencia debe sentirse completamente nativa.
+
+---
+
+## Android nativo: Kotlin y Jetpack Compose
+
+Kotlin con [Jetpack Compose](https://developer.android.com/compose) es el camino recomendado por Google. El sistema XML View más antiguo sigue siendo compatible con código heredado.
+
+**Pros**
+
+- Kotlin es uno de los lenguajes más limpios en los datos de entrenamiento modernos, y el modelo declarativo de Compose se alinea bien con la forma en que los agentes descomponen UI.
+- Toda la cadena de herramientas, desde Gradle hasta el emulador y `adb`, es scriptable desde una terminal. Los agentes pueden instalar builds, capturar logcat y manejar emuladores de extremo a extremo. Eso hace de Android la plataforma móvil más amigable con agentes hoy.
+- Acceso completo a las APIs de la plataforma y un ecosistema sólido respaldado por Google.
+
+**Contras**
+
+- Solo Android implica un segundo framework o equipo para iOS.
+- La larga cola de diferencias entre OEMs, reglas de foreground services y requisitos edge-to-edge siguen requiriendo juicio humano.
+- El tuning de rendimiento de Compose en pantallas complejas no es un lugar donde confiar solo en la salida del agente.
+
+Mejor encaje: productos donde Android es el objetivo principal, o donde quieres una de las experiencias de desarrollo asistido por agente más fluidas disponibles.
+
+---
+
+## Windows: WinUI 3 y el Windows App SDK
+
+Para nuevas apps de escritorio en Windows, [WinUI 3](https://learn.microsoft.com/windows/apps/winui/winui3/) sobre el [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/) es el stack recomendado por Microsoft. WPF y WinForms siguen siendo compatibles para apps existentes y trabajo de línea de negocio.
+
+**Pros**
+
+- Experiencia nativa y moderna en Windows con acceso a las últimas capacidades de la plataforma.
+- Se integra de forma natural con el stack .NET en general: backends de ASP.NET Core, SDKs de Azure y Entity Framework.
+- Una dirección clara para el nuevo desarrollo de escritorio.
+
+**Contras**
+
+- El corpus de WinUI 3 todavía está creciendo, así que las sugerencias de agente aquí son menos maduras que para SwiftUI o Compose.
+- Ningún framework único cubre Windows escritorio y Xbox desde el mismo proyecto hoy.
+
+Para apps de Xbox, UWP sigue siendo el camino a través de la Microsoft Store hoy, y para juegos el [Microsoft Game Development Kit](https://learn.microsoft.com/gaming/gdk/) junto con motores como Unreal y Unity es la respuesta realista. Si Xbox está en tu roadmap, planéalo como una pista separada en lugar de esperar que un framework multiplataforma lo absorba.
+
+Mejor encaje: equipos .NET construyendo apps de escritorio modernas en Windows, especialmente cuando hay un backend compartido o una historia con componentes de Blazor.
+
+---
+
+## .NET MAUI
+
+[.NET MAUI](https://learn.microsoft.com/dotnet/maui/) es la evolución de Xamarin.Forms. Una base de código en C# y XAML apunta a iOS, Android, macOS y Windows. El [roadmap de .NET MAUI](https://github.com/dotnet/maui/wiki/roadmap) se mantiene público.
+
+**Pros**
+
+- Una base de código a través de los cuatro objetivos principales para un equipo nativo en .NET.
+- Integración estrecha con ASP.NET Core, Entity Framework, SDKs de Azure y Blazor Hybrid para compartir UI entre web y nativo.
+- Las herramientas de Visual Studio facilitan la depuración multi-dispositivo, y el hot reload es fiable.
+- Proveedores de componentes maduros (Telerik, Syncfusion, DevExpress) ofrecen suites completas.
+- Microsoft ha nombrado públicamente mejorar la productividad de agentes en .NET y MAUI como un área de inversión, y el corpus está creciendo.
+
+**Contras**
+
+- Corpus de entrenamiento más pequeño que React Native o Flutter hoy, así que las sugerencias de agente en las capas XAML y de handlers pueden ser menos fiables que para frameworks de UI más usados.
+- Las versiones mayores de .NET pueden traer cambios a nivel de plataforma que requieren trabajo de estabilización; quedarse una versión LTS atrás es un patrón común.
+- Las apps de consumo con muchas animaciones suelen encajar mejor en Flutter o nativo.
+
+Mejor encaje: equipos .NET construyendo apps de productividad, empresariales o de línea de negocio a través de móvil y Windows, especialmente cuando el backend ya está en .NET.
+
+---
+
+## React Native
+
+[React Native](https://reactnative.dev/) con la [New Architecture](https://reactnative.dev/architecture/landing-page) (Fabric, JSI, TurboModules y Hermes como motor de JavaScript por defecto) es lo que grandes equipos en Meta, Microsoft, Shopify y Discord usan en producción. [React Native for Windows y macOS](https://microsoft.github.io/react-native-windows/) es mantenido por Microsoft.
+
+**Pros**
+
+- JavaScript y TypeScript se asientan sobre el corpus público más denso de cualquier familia de lenguajes, así que los agentes producen sugerencias fuertes en andamiaje, estado, navegación e integración de APIs.
+- El ecosistema npm y [Expo](https://expo.dev/) eliminan la mayor parte del dolor histórico alrededor de módulos nativos e infraestructura de builds. Un agente puede crear un proyecto, compilarlo y enviar un build a TestFlight o Play Store con mínima intervención humana.
+- Renderiza con componentes UI reales de cada plataforma, así que botones y listas se sienten nativos en cada una.
+
+**Contras**
+
+- Las interfaces con muchas animaciones todavía pueden caer frames bajo carga sostenida, aunque la New Architecture ha cerrado la brecha.
+- Los módulos nativos a veces requieren experiencia de plataforma que los desarrolladores JavaScript no tienen.
+- "Sentirse nativo en cada plataforma" es una característica para algunos productos y una frustración para otros cuando los equipos de diseño quieren UI idéntica pixel a pixel.
+
+Mejor encaje: apps móviles de consumo para iOS y Android donde el tiempo al primer build y la productividad con agentes importan más.
+
+---
+
+## Flutter
+
+[Flutter](https://flutter.dev/) usa Dart y el motor de renderizado Impeller, que ha reemplazado a Skia en iOS y Android.
+
+**Pros**
+
+- La mayor consistencia visual multiplataforma de cualquier opción mainstream, porque Flutter dibuja cada pixel en lugar de envolver la UI de la plataforma.
+- Excelente rendimiento en interfaces con muchas animaciones y gráficos.
+- Hot reload rápido y un sistema de build scriptable.
+- La superficie de API de Flutter es inusualmente consistente y bien documentada, lo que la hace más amigable con agentes de lo que su tamaño de corpus por sí solo sugeriría.
+
+**Contras**
+
+- Dart tiene una comunidad más pequeña que JavaScript, lo que significa un mercado de contratación más reducido.
+- El tamaño de la app tiende a ser mayor porque Flutter incluye su propio motor de renderizado.
+- El soporte web ha mejorado pero sigue siendo más débil que frameworks web dedicados para sitios críticos en SEO.
+
+Mejor encaje: productos donde el diseño debe ser idéntico pixel a pixel entre plataformas, o donde las animaciones y gráficos personalizados son centrales en la experiencia.
+
+---
+
+## Kotlin Multiplatform
+
+[Kotlin Multiplatform](https://www.jetbrains.com/kotlin-multiplatform/) (KMP) comparte lógica de negocio entre plataformas en Kotlin mientras permite que las UIs sigan siendo totalmente nativas. [Compose Multiplatform para iOS alcanzó estabilidad en 2025](https://blog.jetbrains.com/kotlin/2025/05/compose-multiplatform-1-8-0-released-compose-multiplatform-for-ios-is-stable-and-production-ready/), así que la UI compartida también es una opción viable.
+
+**Pros**
+
+- Resuelve la parte del multiplataforma que más duele: lógica de negocio, modelos, redes, validación y persistencia duplicados. El patrón de "núcleo compartido, UI nativa" mantiene SwiftUI en iOS y Jetpack Compose en Android mientras elimina la duplicación por debajo.
+- Kotlin tiene un corpus de entrenamiento sólido, y la separación arquitectónica entre código compartido y específico de plataforma es lo suficientemente clara como para que los agentes la sigan bien.
+- Adopción incremental: puedes introducir KMP en una base de código nativa iOS y Android existente un módulo a la vez.
+
+**Contras**
+
+- El costo de entrada es mayor para equipos sin bases nativas iOS y Android existentes.
+- La interoperabilidad de Kotlin/Native con Swift puede producir salida confusa del agente, especialmente alrededor de concurrencia y las nuevas herramientas de exportación a Swift.
+- La UI compartida con Compose Multiplatform es más nueva que los caminos nativos y el ecosistema iOS-específico a su alrededor sigue madurando.
+
+Mejor encaje: equipos que ya tienen ingenieros nativos de iOS y Android y sienten el dolor de mantener la misma lógica de negocio dos veces.
+
+---
+
+## Un marco de decisión para 2026
+
+Una versión breve que puedes aplicar a la mayoría de las decisiones de producto:
+
+- **App móvil de consumo para iOS y Android, máxima productividad con agentes:** React Native con Expo es el default más fuerte. Flutter es la alternativa cuando la UI idéntica pixel a pixel no es negociable.
+- **Equipo .NET construyendo apps empresariales en móvil y Windows:** .NET MAUI es la opción correcta. Planea Xbox como una pista separada si está en el alcance.
+- **Equipos nativos existentes de iOS y Android con lógica de negocio duplicada:** Kotlin Multiplatform con UIs nativas es el encaje más quirúrgico.
+- **Experiencia mono-plataforma que necesita ir a profundidad:** Quédate en nativo. SwiftUI en iOS o Jetpack Compose en Android, con agentes acelerando todo lo que se pueda acelerar.
+- **App de escritorio Windows-first desde un equipo .NET:** WinUI 3 sobre el Windows App SDK.
+- **Apps de Xbox:** Planea una pista UWP dedicada o usa un motor de juego para juegos.
+
+---
+
+## Reflexiones finales
+
+Los frameworks ya no se evalúan solo por sus características de tiempo de ejecución. También se evalúan por qué tan bien un agente de IA puede leer, escribir y razonar sobre código en ellos. Los frameworks que mejor están en 2026 son aquellos donde la estabilidad, el corpus público y las herramientas scriptables se combinan para permitir a equipos pequeños moverse a la velocidad que un flujo aumentado por agentes hace posible.
+
+La buena noticia es que el costo de aprender un stack nuevo ha caído fuerte. Un equipo que hace dos años habría dudado en adoptar Kotlin Multiplatform o Flutter por la rampa de aprendizaje ahora puede considerarlo seriamente, porque la rampa misma ya no es el cuello de botella que era. Eso cambia cuál framework es la respuesta correcta para muchos productos, y vale la pena revisar decisiones tomadas antes de que los agentes formaran parte del loop.
+
+Elige el framework que encaje con el producto, las plataformas y el equipo que realmente tienes. El agente te ayudará a llegar más rápido de lo que solía.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-05-18-BuildingMobileAppsAgenticEra.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-05-18-BuildingMobileAppsAgenticEra.mdx
@@ -1,0 +1,205 @@
+---
+title: "Construir apps móveis e de dispositivo na era agêntica: um guia prático sobre nativo, MAUI, React Native e mais"
+description: "Um guia de 2026 para construir apps para iOS, Android, Windows e Xbox: as opções realistas, os prós e contras de cada uma e como os agentes de IA estão mudando a forma como os desenvolvedores aprendem e trabalham em diferentes frameworks."
+slug: building-mobile-apps-agentic-era
+authors: [dsanchezcr]
+tags: [Mobile Development, Native Apps, AI, Agentic AI, .NET MAUI, React Native, Flutter, Kotlin Multiplatform, SwiftUI, Jetpack Compose, WinUI, GitHub Copilot, Software Engineering]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-05-18-buildingmobileappsagenticera/building-mobile-apps-agentic-era.jpg
+date: 2026-05-18T10:00
+---
+
+# Construir apps móveis e de dispositivo na era agêntica: um guia prático sobre nativo, MAUI, React Native e mais
+
+Decidir como construir um app móvel ou de dispositivo costumava ser uma decisão contida. Escolher as plataformas, pesar nativo contra multiplataforma, considerar as habilidades da equipe e escolher um framework. Os trade-offs eram principalmente sobre desempenho em tempo de execução, contratação e quanto código realmente dava para compartilhar.
+
+Duas coisas mudaram esse cenário. Primeiro, o cenário de plataformas amadureceu: SwiftUI, Jetpack Compose, WinUI 3, .NET MAUI, a New Architecture do React Native, Flutter com Impeller e Kotlin Multiplatform atingiram um nível de estabilidade que permite uma comparação limpa. Segundo, os agentes de IA agora fazem parte da rotina diária da maioria das equipes. Eles não apenas completam código; eles leem repositórios, resumem APIs desconhecidas, geram scaffolding e encurtam o caminho entre "nunca usei esse framework" e "já entreguei algo com ele". Isso muda como a decisão de framework deve ser feita.
+
+Este guia percorre as opções realistas para iOS, Android, Windows e Xbox, os principais frameworks multiplataforma e os prós e contras de cada um em 2026.
+
+{/* truncate */}
+
+![Construir apps móveis e de dispositivo na era agêntica](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-05-18-buildingmobileappsagenticera/building-mobile-apps-agentic-era.jpg)
+
+---
+
+## Como os agentes de IA mudaram a decisão de framework
+
+O antigo debate sobre frameworks pesava muito a familiaridade da equipe, porque a curva de aprendizado era real. Escolher um stack que a equipe não conhecia significava semanas de rampa: ler documentação, assistir palestras, construir apps de brinquedo e internalizar padrões lentamente antes de qualquer trabalho de produção começar.
+
+Os agentes não eliminaram essa curva, mas a achataram. Um desenvolvedor que nunca tocou em Jetpack Compose, SwiftUI ou Flutter pode sentar com um agente e produzir uma tela funcional em uma tarde. Mais importante ainda, os agentes podem ler uma base de código existente e explicá-la. Uma engenheira sênior entrando em um projeto desconhecido em React Native ou MAUI pode pedir ao agente para mapear a arquitetura, resumir o grafo de navegação ou rastrear como uma chamada de rede flui de um botão até a camada de API. A integração que antes levava uma sprint agora leva um dia.
+
+Isso tem duas consequências práticas para a decisão de framework:
+
+- **A familiaridade da equipe importa menos do que antes.** Ainda é um fator, mas a distância entre "a linguagem que conhecemos" e "a que não conhecemos" diminuiu bastante. Escolher a ferramenta certa para o produto é agora mais acessível do que escolher a ferramenta que a equipe já conhece.
+- **O tamanho e a qualidade do corpus público de um framework importam mais.** Os agentes são mais fortes em stacks com muito código e documentação pública, porque é com isso que foram treinados. JavaScript e TypeScript estão no topo. Kotlin e Swift são sólidos. Dart é menor, mas consistente. C# é bem representado no geral, com dialetos específicos como o XAML do MAUI mais finos, mas em crescimento.
+
+Com essa lente, aqui estão as opções realistas.
+
+---
+
+## iOS nativo: Swift e SwiftUI
+
+Swift com SwiftUI é o caminho recomendado pela Apple para novos apps de iOS e iPadOS. UIKit continua sendo a escolha certa quando você precisa de integração profunda com a plataforma ou está estendendo uma base de código madura.
+
+**Prós**
+
+- A melhor experiência possível em iOS: desempenho nativo, acesso total às APIs da plataforma (CoreML, ARKit, WidgetKit, App Intents) e integração estreita com o ecossistema Apple.
+- SwiftUI já tem um corpus público denso, então os agentes produzem scaffolding confiável para telas, navegação e estado.
+- O Swift Package Manager e as ferramentas de linha de comando amadureceram, então os loops orientados por agente não exigem mais viver dentro do Xcode a cada passo.
+
+**Contras**
+
+- macOS é obrigatório para builds, e assinatura e provisionamento continuam sendo pontos de atrito.
+- Apenas iOS significa uma segunda equipe ou framework para Android.
+- O tuning de desempenho, trabalho com ARKit e casos de borda específicos da plataforma ainda se beneficiam mais do julgamento de engenharia sênior do que da saída do agente.
+
+Melhor encaixe: produtos onde iOS é o alvo principal ou único e a experiência precisa parecer totalmente nativa.
+
+---
+
+## Android nativo: Kotlin e Jetpack Compose
+
+Kotlin com [Jetpack Compose](https://developer.android.com/compose) é o caminho recomendado pelo Google. O sistema XML View mais antigo ainda é suportado para trabalho legado.
+
+**Prós**
+
+- Kotlin é uma das linguagens mais limpas nos dados de treinamento modernos, e o modelo declarativo do Compose se alinha bem com como os agentes decompõem UI.
+- Toda a cadeia de ferramentas, do Gradle ao emulador e `adb`, é scriptável a partir de um terminal. Os agentes podem instalar builds, capturar logcat e operar emuladores de ponta a ponta. Isso faz do Android a plataforma móvel mais amigável a agentes hoje.
+- Acesso completo às APIs da plataforma e um ecossistema sólido apoiado pelo Google.
+
+**Contras**
+
+- Apenas Android significa um segundo framework ou equipe para iOS.
+- A longa cauda de diferenças entre OEMs, regras de foreground services e requisitos edge-to-edge ainda exige julgamento humano.
+- O tuning de desempenho do Compose em telas complexas não é um lugar para confiar apenas na saída do agente.
+
+Melhor encaixe: produtos onde Android é o alvo principal, ou onde você quer uma das experiências de desenvolvimento assistido por agente mais fluidas disponíveis.
+
+---
+
+## Windows: WinUI 3 e o Windows App SDK
+
+Para novos apps de desktop em Windows, [WinUI 3](https://learn.microsoft.com/windows/apps/winui/winui3/) sobre o [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/) é o stack recomendado pela Microsoft. WPF e WinForms continuam suportados para apps existentes e trabalho de linha de negócio.
+
+**Prós**
+
+- Experiência nativa e moderna em Windows com acesso às últimas capacidades da plataforma.
+- Integra-se naturalmente com o stack .NET em geral: backends ASP.NET Core, SDKs do Azure e Entity Framework.
+- Uma direção clara para o novo desenvolvimento de desktop.
+
+**Contras**
+
+- O corpus de WinUI 3 ainda está crescendo, então as sugestões de agente aqui são menos maduras do que para SwiftUI ou Compose.
+- Nenhum framework único cobre Windows desktop e Xbox a partir do mesmo projeto hoje.
+
+Para apps de Xbox, UWP continua sendo o caminho pela Microsoft Store hoje, e para jogos o [Microsoft Game Development Kit](https://learn.microsoft.com/gaming/gdk/) junto com motores como Unreal e Unity é a resposta realista. Se Xbox está no seu roadmap, planeje como uma trilha separada em vez de esperar que um framework multiplataforma absorva.
+
+Melhor encaixe: equipes .NET construindo apps modernos de desktop para Windows, especialmente quando há um backend compartilhado ou uma história com componentes Blazor.
+
+---
+
+## .NET MAUI
+
+[.NET MAUI](https://learn.microsoft.com/dotnet/maui/) é a evolução do Xamarin.Forms. Uma base de código em C# e XAML aponta para iOS, Android, macOS e Windows. O [roadmap do .NET MAUI](https://github.com/dotnet/maui/wiki/roadmap) é mantido publicamente.
+
+**Prós**
+
+- Uma base de código nos quatro alvos principais para uma equipe nativa em .NET.
+- Integração estreita com ASP.NET Core, Entity Framework, SDKs do Azure e Blazor Hybrid para compartilhar UI entre web e nativo.
+- As ferramentas do Visual Studio facilitam a depuração multi-dispositivo, e o hot reload é confiável.
+- Fornecedores maduros de componentes (Telerik, Syncfusion, DevExpress) oferecem suítes completas.
+- A Microsoft nomeou publicamente melhorar a produtividade de agentes em .NET e MAUI como uma área de investimento, e o corpus está crescendo.
+
+**Contras**
+
+- Corpus de treinamento menor que React Native ou Flutter hoje, então as sugestões de agente nas camadas XAML e de handlers podem ser menos confiáveis do que para frameworks de UI mais usados.
+- Versões maiores do .NET podem trazer mudanças em nível de plataforma que exigem trabalho de estabilização; ficar uma versão LTS atrás é um padrão comum.
+- Apps de consumo com muitas animações tendem a encaixar melhor no Flutter ou nativo.
+
+Melhor encaixe: equipes .NET construindo apps de produtividade, empresariais ou de linha de negócio através de móvel e Windows, especialmente quando o backend já está em .NET.
+
+---
+
+## React Native
+
+[React Native](https://reactnative.dev/) com a [New Architecture](https://reactnative.dev/architecture/landing-page) (Fabric, JSI, TurboModules e Hermes como o motor JavaScript padrão) é o que grandes equipes na Meta, Microsoft, Shopify e Discord usam em produção. [React Native para Windows e macOS](https://microsoft.github.io/react-native-windows/) é mantido pela Microsoft.
+
+**Prós**
+
+- JavaScript e TypeScript se apoiam no corpus público mais denso de qualquer família de linguagens, então os agentes produzem sugestões fortes em scaffolding, estado, navegação e integração de APIs.
+- O ecossistema npm e o [Expo](https://expo.dev/) removem a maior parte da dor histórica em torno de módulos nativos e infraestrutura de build. Um agente pode criar um projeto, compilá-lo e enviar um build TestFlight ou Play Store com mínima intervenção humana.
+- Renderiza com componentes de UI reais de cada plataforma, então botões e listas parecem nativos em cada uma.
+
+**Contras**
+
+- Interfaces com muitas animações ainda podem perder frames sob carga sustentada, embora a New Architecture tenha reduzido a distância.
+- Módulos nativos às vezes exigem experiência de plataforma que desenvolvedores JavaScript não têm.
+- "Parecer nativo em cada plataforma" é uma característica para alguns produtos e uma frustração para outros quando equipes de design querem UI idêntica pixel a pixel.
+
+Melhor encaixe: apps móveis de consumo para iOS e Android onde o tempo até o primeiro build e a produtividade com agentes importam mais.
+
+---
+
+## Flutter
+
+[Flutter](https://flutter.dev/) usa Dart e o motor de renderização Impeller, que substituiu o Skia no iOS e Android.
+
+**Prós**
+
+- A maior consistência visual multiplataforma de qualquer opção mainstream, porque o Flutter desenha cada pixel ele mesmo em vez de envolver a UI da plataforma.
+- Excelente desempenho em interfaces com muitas animações e gráficos.
+- Hot reload rápido e um sistema de build scriptável.
+- A superfície de API do Flutter é incomumente consistente e bem documentada, o que a torna mais amigável a agentes do que o tamanho do corpus do Dart sozinho sugeriria.
+
+**Contras**
+
+- Dart tem uma comunidade menor que JavaScript, o que significa um pool de contratação menor.
+- O tamanho do app tende a ser maior porque o Flutter inclui seu próprio motor de renderização.
+- O suporte web melhorou, mas ainda é mais fraco do que frameworks web dedicados para sites críticos em SEO.
+
+Melhor encaixe: produtos onde o design deve ser idêntico pixel a pixel entre plataformas, ou onde animações e gráficos personalizados são centrais à experiência.
+
+---
+
+## Kotlin Multiplatform
+
+[Kotlin Multiplatform](https://www.jetbrains.com/kotlin-multiplatform/) (KMP) compartilha lógica de negócio entre plataformas em Kotlin enquanto permite que as UIs permaneçam totalmente nativas. [O Compose Multiplatform para iOS atingiu estabilidade em 2025](https://blog.jetbrains.com/kotlin/2025/05/compose-multiplatform-1-8-0-released-compose-multiplatform-for-ios-is-stable-and-production-ready/), então UI compartilhada também é uma opção viável.
+
+**Prós**
+
+- Resolve a parte do multiplataforma que mais dói: lógica de negócio, modelos, redes, validação e persistência duplicados. O padrão "núcleo compartilhado, UI nativa" mantém SwiftUI no iOS e Jetpack Compose no Android enquanto elimina a duplicação por baixo.
+- Kotlin tem um corpus de treinamento sólido, e a separação arquitetônica entre código compartilhado e específico de plataforma é clara o suficiente para que os agentes a sigam bem.
+- Adoção incremental: você pode introduzir KMP em uma base de código nativa iOS e Android existente um módulo de cada vez.
+
+**Contras**
+
+- O custo de entrada é maior para equipes sem fundações nativas iOS e Android existentes.
+- A interoperabilidade Kotlin/Native com Swift pode produzir saída confusa do agente, especialmente em torno de concorrência e das novas ferramentas de exportação para Swift.
+- UI compartilhada via Compose Multiplatform é mais nova que os caminhos nativos e o ecossistema iOS-específico em torno dela ainda está amadurecendo.
+
+Melhor encaixe: equipes que já têm engenheiros nativos de iOS e Android e sentem a dor de manter a mesma lógica de negócio duas vezes.
+
+---
+
+## Um framework de decisão para 2026
+
+Uma versão curta que você pode aplicar à maioria das decisões de produto:
+
+- **App móvel de consumo para iOS e Android, máxima produtividade com agentes:** React Native com Expo é o default mais forte. Flutter é a alternativa quando UI idêntica pixel a pixel não é negociável.
+- **Equipe .NET construindo apps empresariais em móvel e Windows:** .NET MAUI é a escolha certa. Planeje Xbox como uma trilha separada se estiver no escopo.
+- **Equipes nativas existentes de iOS e Android com lógica de negócio duplicada:** Kotlin Multiplatform com UIs nativas é o encaixe mais cirúrgico.
+- **Experiência mono-plataforma que precisa ir fundo:** Fique no nativo. SwiftUI no iOS ou Jetpack Compose no Android, com agentes acelerando tudo o que pode ser acelerado.
+- **App de desktop Windows-first de uma equipe .NET:** WinUI 3 sobre o Windows App SDK.
+- **Apps de Xbox:** Planeje uma trilha UWP dedicada ou use um motor de jogo para jogos.
+
+---
+
+## Reflexões finais
+
+Frameworks não são mais avaliados apenas por suas características de tempo de execução. Eles também são avaliados pelo quão bem um agente de IA pode ler, escrever e raciocinar sobre código neles. Os frameworks que estão indo melhor em 2026 são aqueles onde estabilidade, corpus público e ferramentas scriptáveis se combinam para permitir que equipes pequenas se movam na velocidade que um fluxo aumentado por agentes torna possível.
+
+A boa notícia é que o custo de aprender um novo stack caiu bastante. Uma equipe que dois anos atrás teria hesitado em adotar Kotlin Multiplatform ou Flutter por causa da rampa de aprendizado agora pode considerar seriamente, porque a própria rampa não é mais o gargalo que era. Isso muda qual framework é a resposta certa para muitos produtos, e vale a pena revisitar decisões tomadas antes de os agentes fazerem parte do loop.
+
+Escolha o framework que se encaixa no produto, nas plataformas e na equipe que você realmente tem. O agente vai te ajudar a chegar lá mais rápido do que costumava.


### PR DESCRIPTION
Add a new blog post (2026-05-18) by dsanchezcr: "Building mobile and device apps in the agentic era", plus Spanish and Portuguese translations. The article compares native and cross-platform options (SwiftUI, Jetpack Compose, WinUI, .NET MAUI, React Native, Flutter, Kotlin Multiplatform) and explains how AI agents are reshaping framework decisions and developer workflows.