### PR TITLE
Add webinar blog post and translations

### DIFF
--- a/blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
+++ b/blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
@@ -1,0 +1,33 @@
+---
+title: "DevOps Foundations for the AI Agentic Era (Microsoft Reactor Webinar)"
+description: "Watch the recording of my Microsoft Reactor webinar on DevOps foundations for the AI agentic era, including a live demo you can explore yourself since it is public and open source."
+slug: devops-foundations-ai-agentic-era-webinar
+authors: [dsanchezcr]
+tags: [DevOps, AI, Agentic AI, GitHub Copilot, Azure, Microsoft Reactor, Webinar]
+enableComments: true
+hide_table_of_contents: true
+image: https://img.youtube.com/vi/rgO_-cZdVIY/maxresdefault.jpg
+date: 2026-06-14T10:00
+---
+
+import YouTubeEmbed from '@site/src/components/YouTubeEmbed';
+
+# DevOps Foundations for the AI Agentic Era (Microsoft Reactor Webinar)
+
+On Friday, June 12, 2026, I delivered a webinar on the Microsoft Reactor YouTube channel called **DevOps Foundations for the AI Agentic Era**. The recording is now available, so you can watch it anytime.
+
+{/* truncate */}
+
+<YouTubeEmbed videoId="rgO_-cZdVIY" title="DevOps Foundations for the AI Agentic Era" />
+
+## What the session covers
+
+The webinar walks through why strong DevOps practices matter more than ever once AI agents join your delivery loop:
+
+- How version control, automated testing, CI/CD, and security scanning become the guardrails that keep agents productive instead of risky.
+- Where human oversight fits when agents write, review, and ship code at machine speed.
+- Practical patterns to adopt agentic workflows without sacrificing quality, security, or trust.
+
+## Explore the demo
+
+The session includes a live demo, and the best part is that all the demo content is **public and open source**, so you can explore it, fork it, and try it yourself.

--- a/i18n/es/docusaurus-plugin-content-blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
@@ -1,0 +1,33 @@
+---
+title: "Fundamentos de DevOps para la era agéntica de la IA (Webinar de Microsoft Reactor)"
+description: "Mira la grabación de mi webinar en Microsoft Reactor sobre los fundamentos de DevOps para la era agéntica de la IA, con una demo en vivo que puedes explorar por tu cuenta porque es pública y de código abierto."
+slug: devops-foundations-ai-agentic-era-webinar
+authors: [dsanchezcr]
+tags: [DevOps, AI, Agentic AI, GitHub Copilot, Azure, Microsoft Reactor, Webinar]
+enableComments: true
+hide_table_of_contents: true
+image: https://img.youtube.com/vi/rgO_-cZdVIY/maxresdefault.jpg
+date: 2026-06-14T10:00
+---
+
+import YouTubeEmbed from '@site/src/components/YouTubeEmbed';
+
+# Fundamentos de DevOps para la era agéntica de la IA (Webinar de Microsoft Reactor)
+
+El viernes 12 de junio de 2026 impartí un webinar en el canal de YouTube de Microsoft Reactor llamado **DevOps Foundations for the AI Agentic Era**. La grabación ya está disponible para que la veas cuando quieras. La sesión está en inglés.
+
+{/* truncate */}
+
+<YouTubeEmbed videoId="rgO_-cZdVIY" title="DevOps Foundations for the AI Agentic Era" />
+
+## Qué cubre la sesión
+
+El webinar explica por qué las buenas prácticas de DevOps importan más que nunca cuando los agentes de IA se suman a tu ciclo de entrega:
+
+- Cómo el control de versiones, las pruebas automatizadas, CI/CD y el análisis de seguridad se convierten en las barreras que mantienen a los agentes productivos en lugar de riesgosos.
+- Dónde encaja la supervisión humana cuando los agentes escriben, revisan y despliegan código a la velocidad de la máquina.
+- Patrones prácticos para adoptar flujos de trabajo agénticos sin sacrificar calidad, seguridad ni confianza.
+
+## Explora la demo
+
+La sesión incluye una demo en vivo, y lo mejor es que todo el contenido de la demo es **público y de código abierto**, así que puedes explorarlo, hacer un fork y probarlo tú mismo.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
@@ -1,0 +1,33 @@
+---
+title: "Fundamentos de DevOps para a era agêntica da IA (Webinar da Microsoft Reactor)"
+description: "Assista à gravação do meu webinar na Microsoft Reactor sobre os fundamentos de DevOps para a era agêntica da IA, com uma demo ao vivo que você pode explorar por conta própria porque é pública e de código aberto."
+slug: devops-foundations-ai-agentic-era-webinar
+authors: [dsanchezcr]
+tags: [DevOps, AI, Agentic AI, GitHub Copilot, Azure, Microsoft Reactor, Webinar]
+enableComments: true
+hide_table_of_contents: true
+image: https://img.youtube.com/vi/rgO_-cZdVIY/maxresdefault.jpg
+date: 2026-06-14T10:00
+---
+
+import YouTubeEmbed from '@site/src/components/YouTubeEmbed';
+
+# Fundamentos de DevOps para a era agêntica da IA (Webinar da Microsoft Reactor)
+
+Na sexta-feira, 12 de junho de 2026, apresentei um webinar no canal do YouTube da Microsoft Reactor chamado **DevOps Foundations for the AI Agentic Era**. A gravação já está disponível para você assistir quando quiser. A sessão é em inglês.
+
+{/* truncate */}
+
+<YouTubeEmbed videoId="rgO_-cZdVIY" title="DevOps Foundations for the AI Agentic Era" />
+
+## O que a sessão aborda
+
+O webinar mostra por que boas práticas de DevOps importam mais do que nunca quando os agentes de IA entram no seu ciclo de entrega:
+
+- Como controle de versão, testes automatizados, CI/CD e análise de segurança se tornam as proteções que mantêm os agentes produtivos em vez de arriscados.
+- Onde a supervisão humana se encaixa quando os agentes escrevem, revisam e publicam código na velocidade da máquina.
+- Padrões práticos para adotar fluxos de trabalho agênticos sem sacrificar qualidade, segurança ou confiança.
+
+## Explore a demo
+
+A sessão inclui uma demo ao vivo, e o melhor é que todo o conteúdo da demo é **público e de código aberto**, então você pode explorá-lo, fazer um fork e testá-lo você mesmo.


### PR DESCRIPTION
Add a new blog post announcing the Microsoft Reactor webinar "DevOps Foundations for the AI Agentic Era" with embedded YouTube video and session details. Also add Spanish and Portuguese translated versions. Files added:
- blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
- i18n/es/docusaurus-plugin-content-blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx
- i18n/pt/docusaurus-plugin-content-blog/2026-06-14-DevOpsFoundationsAgenticEraWebinar.mdx The post includes metadata, tags, and an open-source demo note.