### PR TITLE
Add 'Mastering Generative AI' blog post with i18n

### DIFF
--- a/blog/2026-06-22-MasteringGenerativeAI.mdx
+++ b/blog/2026-06-22-MasteringGenerativeAI.mdx
@@ -1,0 +1,213 @@
+---
+title: "Mastering Generative AI: The Architecture of a System of Intelligence"
+description: "Generative AI is not a chatbot. It is a system. This is a mental model for how eight building blocks (agents, subagents, skills, context, memory, prompts, notebooks, and projects) work together to turn a capable model into scalable, real-world intelligence."
+slug: mastering-generative-ai-systems-of-intelligence
+authors: [dsanchezcr]
+tags: [AI, Generative AI, Agentic AI, Software Architecture, Enterprise AI, Software Engineering]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-22-mastering-generative-ai/mastering-generative-ai.jpg
+date: 2026-06-22T10:00
+---
+
+# Mastering Generative AI: The Architecture of a System of Intelligence
+
+_Eight building blocks that turn a capable model into a system that ships real work: agents, subagents, skills, context, memory, prompts, notebooks, and projects._
+
+Most people believe they are using Generative AI when they open a chat window and type a question. They are using the least interesting part of it. The chat box is the front door, not the house.
+
+{/* truncate */}
+
+The reframing that matters is this: a model that answers questions is a feature. A system that pursues outcomes is a different category of thing. The first is a chatbot. The second is a **system of intelligence**, and the gap between them is not bigger models. It is architecture.
+
+Raw capability is commoditizing fast. Every serious model can now write code, summarize a document, and draft a plan. That is no longer where advantage lives. Advantage lives in how you assemble capability into something that remembers, specializes, grounds itself in your data, and coordinates its own work. That assembly has parts, and the parts have names. This post is the mental model that connects them.
+
+---
+
+## The Unifying Framework: Intelligence as an Operating System
+
+Stop picturing a genius in a box. Picture a high functioning team working inside a well defined workspace.
+
+A team has people who own outcomes, specialists they pull in when needed, shared playbooks everyone follows, awareness of the situation in front of them, institutional knowledge that survives turnover, clear assignments, a workbench where ideas get tested, and a mission with boundaries. A system of intelligence has exactly the same parts. We just give them different names.
+
+Here is the full map:
+
+| Building block | What it is | Its job in the system |
+|---|---|---|
+| **Prompt** | A structured statement of intent | Sets the work in motion |
+| **Agent** | An autonomous unit that owns an outcome | Decides, acts, and verifies |
+| **Subagent** | A scoped specialist an agent delegates to | Handles depth without polluting the main flow |
+| **Skill** | A packaged, reusable capability | Encodes expertise so it is applied consistently |
+| **Context** | The information relevant right now | Grounds the work in the current situation |
+| **Memory** | Information that persists across time | Lets the system learn instead of restarting |
+| **Notebook** | A shared, iterative workspace | Where humans and agents think together |
+| **Project** | The mission, the boundary, the grounded data | Holds everything and defines what is in scope |
+
+The diagram below is the model to keep in your head. Read it as a single workspace (the Project) inside which intent flows into an agent, the agent delegates and applies skills, while context and memory continuously feed and record the work.
+
+```mermaid
+flowchart TD
+    subgraph PROJECT["PROJECT: the mission, the boundary, the grounded data"]
+        P["PROMPT: the intent that starts the work"]
+        A["AGENT: owns the outcome"]
+        SA["SUBAGENTS: specialists it delegates to"]
+        SK["SKILLS: durable, reusable capabilities"]
+        C["CONTEXT: what matters right now"]
+        M[("MEMORY: what persists across time")]
+        N["NOTEBOOK: the shared workbench"]
+
+        P --> A
+        A -->|delegates to| SA
+        A -->|applies| SK
+        SA -->|applies| SK
+        C -.->|grounds| A
+        M -.->|hydrates| C
+        A -.->|writes back to| M
+        N <-->|iterate together| A
+    end
+```
+
+Now let us walk through each block: what it is, the role it plays, and how it interacts with the others. The order is a narrative, from the spark of intent to the boundary that contains the whole system.
+
+---
+
+## Prompts: Intent, Not Incantation
+
+A prompt is a statement of intent. That is the entire definition, and most of the confusion in this field comes from forgetting it.
+
+The popular misconception is that prompting is a bag of tricks: magic phrases, role play openers, and threats that supposedly coax better answers out of a model. That is folklore. The prompts that hold up are the ones that communicate intent with precision: the goal, the constraints, the inputs, the definition of done. A strong prompt reads less like a spell and more like a small specification. I made this argument in depth in [From Prompts to Specifications](/blog/from-prompts-to-specifications), and it is the foundation everything else rests on.
+
+Here is the role a prompt actually plays: it is the interface between human intent and machine action. In a system of intelligence, a prompt rarely travels alone. It arrives carrying context, it is interpreted by an agent, and it is shaped by the memory and skills available in the project. The same words produce wildly different results depending on what surrounds them.
+
+The mistake to avoid is treating the prompt as the whole system. Teams pour weeks into prompt tuning while ignoring the context the prompt runs in and the memory it could draw on. That is optimizing the question while starving the answer. A precise prompt with no context is a precise question shouted into an empty room.
+
+---
+
+## Agents: The Unit That Owns an Outcome
+
+An agent is an autonomous unit that owns an outcome. The keyword is *owns*. A chatbot responds to a turn. An agent pursues a goal: it plans, takes actions, observes results, corrects course, and decides when the work is actually done.
+
+This is the leap from answering to achieving. Ask a model to "summarize this report" and you get text. Give an agent the goal "produce the weekly risk briefing and flag anything that needs an executive decision" and it has to retrieve the right documents, apply judgment, use tools, and assemble a result that meets a standard. The agent is the actor in the system, the thing that turns intent into completed work.
+
+An agent interacts with everything else: it reads **context** to understand the situation, draws on **memory** to avoid relearning what it already knows, applies **skills** to perform specialized steps reliably, and delegates to **subagents** when a task needs depth it should not handle inline. The prompt sets its direction. The project draws its boundary.
+
+The common failure here is the monolith: one giant agent with a sprawling instruction set asked to do everything. It works in demos and collapses in production, because a single context window cannot hold a whole business process without losing the thread. Real systems decompose. Which is exactly why subagents exist.
+
+---
+
+## Subagents: Delegation as a Design Principle
+
+A subagent is a scoped specialist that an agent calls to handle one well defined job. If the agent is the lead, subagents are the experts it brings in for a specific question and then releases.
+
+The reason subagents matter is not organizational tidiness. It is a hard constraint of how these systems work: attention and context are finite. When a lead agent tries to research, write, test, and review inside a single conversation, every one of those concerns competes for the same limited working space, and quality degrades. Delegating a self contained task to a subagent gives that task its own fresh space to work in. The subagent goes deep, returns a clean result, and the lead agent stays focused on the outcome it owns. I explored how to compose teams of these agents in [Building Your AI Agent Team](/blog/building-your-ai-agent-team).
+
+Consider a developer workflow. The lead agent is implementing a feature. It dispatches an exploration subagent to map how an unfamiliar module works, and a testing subagent to write and run the verification suite. Each subagent burns through a large amount of intermediate reasoning that the lead never has to see. What returns is a summary: "here is how the module works" and "here are the results." The lead stays clean, oriented, and effective.
+
+Subagents interact with skills (they often exist to apply one deeply), with context (they receive a focused slice, not the whole world), and with the lead agent through a narrow, well defined handoff. Used well, they are how a system scales beyond what any single agent could hold in its head.
+
+---
+
+## Skills: Capability You Can Reuse
+
+A skill is a packaged, reusable capability: a defined procedure, with the knowledge and steps to perform it, that any agent can apply. If a prompt is a one time request, a skill is a competency the system keeps.
+
+This is the difference between explaining how to do something every single time and teaching it once. Without skills, expertise lives in whoever happened to write the best prompt, and it evaporates when the conversation closes. With skills, that expertise becomes a durable, versioned asset. "How we triage a support ticket," "how we format a compliance report," "how we run our deployment checklist": each becomes a skill an agent invokes rather than a process it improvises.
+
+The power of skills is composition. The same skill can be applied by many agents and by many subagents. A single skill can be improved once and instantly raise the quality of every workflow that uses it. Skills interact with agents (which decide when to apply them), with context (which supplies the specifics the skill operates on), and with memory (which can refine how a skill is used over time).
+
+The mistake is treating skills as throwaway scripts instead of governed, shared assets. When skills are scattered and personal, you get the same fragmentation that package managers once solved for code dependencies: everyone reinvents the same capability slightly differently, and quality is a lottery.
+
+---
+
+## Context: Situational Awareness in the Moment
+
+Context is the information that is relevant right now. Not everything the system knows, just what matters for the task in front of it: the current document, the relevant records, the state of the conversation, the data retrieved for this specific decision.
+
+Context is the most underestimated block in the entire model, and the source of most disappointing results. A model with no context is brilliant and blind. It reasons beautifully about nothing in particular. The leap in quality almost never comes from a better prompt. It comes from putting the right information in front of the model at the right moment. In the enterprise this has a name: grounding. You connect the system to your data, retrieve the passages that matter, and let the model reason over reality instead of its generic training.
+
+But context has a sharp edge, and it cuts the opposite way from what people assume. The instinct is to dump everything in, on the theory that more information is safer. It is not. An overstuffed context buries the signal that matters under noise, and quality falls. The discipline of context is curation: retrieving precisely what is relevant and nothing more. Context interacts with memory (which decides what is worth recalling into the moment), with prompts (which it grounds), and with agents (which act on it).
+
+Here is the rule worth memorizing: most "the AI gave a bad answer" problems are not reasoning failures. They are context failures.
+
+---
+
+## Memory: Learning Across Time
+
+Memory is information that persists across time, beyond a single task or conversation. If context is what is on the desk right now, memory is the filing cabinet, the institutional knowledge, the relationship that deepens with every interaction.
+
+Without memory, every session starts from zero. The system is permanently meeting you for the first time, relearning your conventions, repeating questions you already answered, forgetting the decision it helped you make yesterday. It is intelligence with amnesia, and it caps the value of everything else. With memory, the system compounds. It remembers your preferences, your past decisions and the reasons behind them, the corrections you made, the way your domain actually works.
+
+Memory and context are partners, not synonyms, and conflating them is a common and costly error. Memory is the durable store. Context is the working set pulled from it for the current task. Memory hydrates context: it decides what from the long term record is worth surfacing into the present moment. Agents write back to memory as they work, so the system that handles a task next week is smarter than the one that handled it today. That feedback loop, write and recall, is what separates a tool you operate from a system that learns.
+
+The mistake is skipping memory entirely because it is harder to build than a prompt. Teams ship stateless systems, then wonder why the experience feels shallow and why users never develop trust. Trust is built on being remembered.
+
+---
+
+## Notebooks: The Shared Workbench
+
+A notebook is a shared, iterative workspace where humans and agents think together. It is not a chat log that scrolls away and it is not finished software. It is the bench where work is composed, executed, inspected, and refined, with the reasoning left visible.
+
+The role of the notebook is to make the process legible. In a chat, the conversation vanishes upward and the steps blur together. In a notebook, intent, code, results, and commentary live side by side as durable artifacts you can rerun, adjust, and build on. This is where a human stays in the loop, not as a bystander watching an agent work, but as a collaborator who can inspect a step, change an assumption, and run it again. It is the natural habitat of the collaboration patterns I described in [Humans and Agents](/blog/humans-and-agents-collaboration-patterns).
+
+Notebooks interact with nearly everything: agents do work inside them, skills are applied and tested in them, context is loaded and examined in them, and the results that prove out can be promoted into durable skills or production workflows. The notebook is where experimentation becomes understanding.
+
+The mistake is letting valuable work die in the notebook. A notebook is for iteration, not for permanence. When something you discovered there proves useful, it should graduate: into a skill, into an agent's instructions, into the project itself. A notebook full of insight that never gets promoted is a workbench full of finished parts no one ever installs.
+
+---
+
+## Projects: The Boundary That Makes It a System
+
+A project is the mission, the boundary, and the grounded data that hold everything else together. It is the container. Every other block, the prompts, the agents, the subagents, the skills, the context, the memory, the notebooks, lives inside a project and is given meaning by it.
+
+The project is what makes the difference between a clever assistant and a system that can be trusted with real work. It defines scope: what is in bounds and what is not. It defines grounding: which data the system is connected to and allowed to reason over. It defines the shared assets: the agents and skills available, the memory that accumulates, the conventions everyone follows. A project turns a pile of capable parts into a coherent whole with a purpose. This is the spirit of building software for systems, not sessions, which I unpacked in [Designing Software for an Agent First World](/blog/designing-software-agent-first-world).
+
+In practice the project is where governance lives, and governance is what makes enterprise adoption possible at all. Boundaries are not bureaucracy. They are what let you give a system access to real data and real actions without losing control of either. The project is where you decide what the system is allowed to know, allowed to do, and accountable for.
+
+The mistake is running without one: agents with no boundary, pulling from everything, grounded in nothing in particular, accountable to no defined scope. That is not a system. It is a liability with good grammar.
+
+---
+
+## Orchestration Is the Whole Point
+
+Here is the thesis the entire model is built to deliver: the value is not in the blocks. It is in how they are coordinated. A system of intelligence is not eight features bolted together. It is one orchestrated flow.
+
+Watch the parts move together in a single enterprise scenario. A team needs to prepare an account renewal briefing.
+
+1. The **project** sets the stage. It is the account workspace, grounded in the customer's usage data, support history, and the team's playbooks. It defines what is in scope and what the system may touch.
+2. A **prompt** states the intent: produce a renewal briefing and flag any risk that needs a leader's decision.
+3. An **agent** takes ownership of that outcome. It does not just answer. It plans the work.
+4. It delegates to **subagents**: one pulls and analyzes usage trends, another scans the support history for unresolved friction. Each works in its own focused space and returns a clean result.
+5. Throughout, the agents apply **skills**: the standard way the organization assesses account health and drafts an executive brief, applied consistently rather than improvised.
+6. Everything is grounded in **context**: this specific account's real data, retrieved precisely, not a generic template.
+7. The work draws on **memory**: what the team learned about this account last quarter, the concerns raised before, the commitments made. And it writes back, so next quarter starts ahead.
+8. A human reviews and refines in a **notebook**, adjusting emphasis, correcting a nuance, approving the result.
+
+No single block did anything miraculous. The outcome (a grounded, trustworthy briefing produced in a fraction of the usual time) came from the coordination. Remove any one block and it degrades: no memory and it forgets the relationship, no context and it hallucinates the details, no subagents and the lead drowns in depth, no project and it has no right to the data in the first place.
+
+This is the shift in thinking that mastery requires. Stop asking "what can the model do?" Start asking "how do I orchestrate these blocks into a flow that produces the outcome?" The first question has roughly the same answer for everyone. The second is where real systems, and real advantage, are built.
+
+---
+
+## The Mistakes That Keep Systems Shallow
+
+The failures in this field are remarkably consistent. Almost all of them come from over investing in one block while neglecting the system.
+
+- **Worshipping the prompt.** Treating prompt wording as the master skill while ignoring the context it runs in and the memory it could use. A perfect prompt over an empty context is still an empty answer.
+- **Confusing the model for the system.** Believing a more capable model removes the need for architecture. It does the opposite. A stronger engine makes good orchestration more valuable, not less.
+- **Building the monolith.** One sprawling agent asked to do everything, instead of a lead that delegates to focused subagents. It demos well and fails under real load.
+- **Skipping memory.** Shipping stateless systems that meet the user for the first time every session, then wondering why trust never forms.
+- **Starving or flooding context.** Giving the model nothing to ground on, or burying the signal under everything you could find. Both produce bad answers for opposite reasons.
+- **Treating skills as scratch work.** Letting capability live in personal prompts instead of shared, versioned assets, so quality becomes a lottery and nothing compounds.
+- **Running without a project.** No boundary, no grounding, no accountability. Capable, connected, and ungoverned is not a feature. It is exposure.
+
+Notice the pattern. Every one of these is a coordination failure dressed up as a capability problem. The model is rarely the bottleneck. The architecture around it almost always is.
+
+---
+
+## What Mastery Looks Like Next
+
+The first era of Generative AI rewarded the clever prompt. That era is ending. The phrasing that felt like a competitive edge is becoming table stakes, because the models are absorbing that cleverness into their defaults.
+
+The next era rewards a different skill: the ability to compose. The people and organizations who pull ahead will be the ones who think like architects of intelligence, who design how agents, subagents, skills, context, memory, prompts, notebooks, and projects fit together into systems that learn, specialize, and stay grounded in reality. The applications that define the next decade will not be prompted into existence. They will be assembled, with the same rigor we bring to any serious software system.
+
+So here is the takeaway worth keeping. Generative AI is not a chatbot you query. It is a system you architect. Mastery is not knowing the magic words. It is knowing the building blocks, and knowing how to make them work as one. The model is the easy part. The system is the whole game.

--- a/i18n/es/docusaurus-plugin-content-blog/2026-06-22-MasteringGenerativeAI.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-06-22-MasteringGenerativeAI.mdx
@@ -1,0 +1,213 @@
+---
+title: "Dominar la IA generativa: la arquitectura de un sistema de inteligencia"
+description: "La IA generativa no es un chatbot. Es un sistema. Este es un modelo mental de cómo ocho bloques de construcción (agentes, subagentes, habilidades, contexto, memoria, prompts, notebooks y proyectos) trabajan juntos para convertir un modelo capaz en inteligencia real y escalable."
+slug: mastering-generative-ai-systems-of-intelligence
+authors: [dsanchezcr]
+tags: [AI, Generative AI, Agentic AI, Software Architecture, Enterprise AI, Software Engineering]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-22-mastering-generative-ai/mastering-generative-ai.jpg
+date: 2026-06-22T10:00
+---
+
+# Dominar la IA generativa: la arquitectura de un sistema de inteligencia
+
+_Ocho bloques de construcción que convierten un modelo capaz en un sistema que entrega trabajo real: agentes, subagentes, habilidades, contexto, memoria, prompts, notebooks y proyectos._
+
+La mayoría cree que está usando IA generativa cuando abre una ventana de chat y escribe una pregunta. Está usando la parte menos interesante de todo esto. El chat es la puerta de entrada, no la casa.
+
+{/* truncate */}
+
+El replanteamiento que importa es este: un modelo que responde preguntas es una funcionalidad. Un sistema que persigue resultados es una categoría distinta. Lo primero es un chatbot. Lo segundo es un **sistema de inteligencia**, y la diferencia entre ambos no son modelos más grandes. Es arquitectura.
+
+La capacidad bruta se está volviendo un commodity a gran velocidad. Cualquier modelo serio ya escribe código, resume un documento y redacta un plan. Ahí ya no vive la ventaja. La ventaja vive en cómo ensamblas esa capacidad en algo que recuerda, se especializa, se fundamenta en tus datos y coordina su propio trabajo. Ese ensamblaje tiene partes, y las partes tienen nombre. Este artículo es el modelo mental que las conecta.
+
+---
+
+## El marco unificador: la inteligencia como sistema operativo
+
+Deja de imaginar a un genio dentro de una caja. Imagina un equipo de alto rendimiento trabajando dentro de un espacio de trabajo bien definido.
+
+Un equipo tiene personas que son dueñas de los resultados, especialistas a los que recurre cuando hace falta, manuales compartidos que todos siguen, conciencia de la situación que tiene enfrente, conocimiento institucional que sobrevive a la rotación, asignaciones claras, un banco de trabajo donde se prueban las ideas y una misión con límites. Un sistema de inteligencia tiene exactamente las mismas partes. Solo les damos nombres distintos.
+
+Este es el mapa completo:
+
+| Bloque de construcción | Qué es | Su función en el sistema |
+|---|---|---|
+| **Prompt** | Una declaración estructurada de intención | Pone el trabajo en marcha |
+| **Agente** | Una unidad autónoma dueña de un resultado | Decide, actúa y verifica |
+| **Subagente** | Un especialista acotado al que un agente delega | Aporta profundidad sin contaminar el flujo principal |
+| **Habilidad** | Una capacidad empaquetada y reutilizable | Codifica la experiencia para aplicarla de forma consistente |
+| **Contexto** | La información relevante en este momento | Fundamenta el trabajo en la situación actual |
+| **Memoria** | Información que persiste a lo largo del tiempo | Permite que el sistema aprenda en vez de empezar de cero |
+| **Notebook** | Un espacio de trabajo compartido e iterativo | Donde humanos y agentes piensan juntos |
+| **Proyecto** | La misión, el límite y los datos fundamentados | Contiene todo y define qué está dentro del alcance |
+
+El diagrama de abajo es el modelo que conviene tener en la cabeza. Léelo como un único espacio de trabajo (el proyecto) dentro del cual la intención fluye hacia un agente, el agente delega y aplica habilidades, mientras el contexto y la memoria alimentan y registran el trabajo de forma continua.
+
+```mermaid
+flowchart TD
+    subgraph PROYECTO["PROYECTO: la misión, el límite, los datos fundamentados"]
+        P["PROMPT: la intención que inicia el trabajo"]
+        A["AGENTE: dueño del resultado"]
+        SA["SUBAGENTES: especialistas a los que delega"]
+        SK["HABILIDADES: capacidades duraderas y reutilizables"]
+        C["CONTEXTO: lo que importa ahora mismo"]
+        M[("MEMORIA: lo que persiste en el tiempo")]
+        N["NOTEBOOK: el banco de trabajo compartido"]
+
+        P --> A
+        A -->|delega en| SA
+        A -->|aplica| SK
+        SA -->|aplica| SK
+        C -.->|fundamenta| A
+        M -.->|hidrata| C
+        A -.->|escribe en| M
+        N <-->|iteran juntos| A
+    end
+```
+
+Ahora recorramos cada bloque: qué es, el papel que cumple y cómo interactúa con los demás. El orden es una narrativa, desde la chispa de la intención hasta el límite que contiene todo el sistema.
+
+---
+
+## Prompts: intención, no conjuro
+
+Un prompt es una declaración de intención. Esa es toda la definición, y buena parte de la confusión en este campo viene de olvidarla.
+
+El malentendido popular es que escribir prompts es una bolsa de trucos: frases mágicas, aperturas de juego de roles y amenazas que supuestamente le sacan mejores respuestas al modelo. Eso es folclore. Los prompts que aguantan son los que comunican la intención con precisión: el objetivo, las restricciones, las entradas, la definición de terminado. Un buen prompt se parece menos a un hechizo y más a una pequeña especificación. Desarrollé este argumento a fondo en [De prompts a especificaciones](/blog/from-prompts-to-specifications), y es la base sobre la que se apoya todo lo demás.
+
+Este es el papel que realmente cumple un prompt: es la interfaz entre la intención humana y la acción de la máquina. En un sistema de inteligencia, un prompt rara vez viaja solo. Llega cargando contexto, lo interpreta un agente y lo moldean la memoria y las habilidades disponibles en el proyecto. Las mismas palabras producen resultados radicalmente distintos según lo que las rodea.
+
+El error a evitar es tratar el prompt como si fuera el sistema entero. Hay equipos que invierten semanas en ajustar prompts mientras ignoran el contexto en el que ese prompt se ejecuta y la memoria de la que podría tomar. Eso es optimizar la pregunta mientras se mata de hambre a la respuesta. Un prompt preciso sin contexto es una pregunta precisa gritada en una habitación vacía.
+
+---
+
+## Agentes: la unidad dueña de un resultado
+
+Un agente es una unidad autónoma dueña de un resultado. La palabra clave es *dueña*. Un chatbot responde a un turno. Un agente persigue un objetivo: planifica, actúa, observa los resultados, corrige el rumbo y decide cuándo el trabajo está realmente terminado.
+
+Este es el salto de responder a lograr. Pídele a un modelo que "resuma este informe" y obtienes texto. Dale a un agente el objetivo "produce el informe semanal de riesgos y marca cualquier cosa que requiera una decisión ejecutiva" y tiene que recuperar los documentos correctos, aplicar criterio, usar herramientas y armar un resultado que cumpla un estándar. El agente es el actor del sistema, lo que convierte la intención en trabajo terminado.
+
+Un agente interactúa con todo lo demás: lee el **contexto** para entender la situación, recurre a la **memoria** para no reaprender lo que ya sabe, aplica **habilidades** para ejecutar pasos especializados de forma confiable y delega en **subagentes** cuando una tarea requiere una profundidad que no debería manejar en línea. El prompt fija su dirección. El proyecto traza su límite.
+
+El fallo típico aquí es el monolito: un agente gigante con un conjunto de instrucciones desbordado al que se le pide hacer todo. Funciona en demos y colapsa en producción, porque una sola ventana de contexto no puede sostener un proceso de negocio completo sin perder el hilo. Los sistemas reales se descomponen. Y por eso existen los subagentes.
+
+---
+
+## Subagentes: la delegación como principio de diseño
+
+Un subagente es un especialista acotado al que un agente llama para resolver una tarea bien definida. Si el agente es el líder, los subagentes son los expertos que convoca para una pregunta específica y luego libera.
+
+La razón por la que los subagentes importan no es prolijidad organizativa. Es una restricción dura del funcionamiento de estos sistemas: la atención y el contexto son finitos. Cuando un agente líder intenta investigar, escribir, probar y revisar dentro de una sola conversación, cada una de esas preocupaciones compite por el mismo espacio de trabajo limitado, y la calidad se degrada. Delegar una tarea autocontenida a un subagente le da a esa tarea su propio espacio fresco para trabajar. El subagente profundiza, devuelve un resultado limpio y el agente líder se mantiene enfocado en el resultado del que es dueño. Exploré cómo componer equipos de estos agentes en [Construye tu equipo de agentes de IA](/blog/building-your-ai-agent-team).
+
+Piensa en un flujo de desarrollo. El agente líder está implementando una funcionalidad. Despacha un subagente de exploración para mapear cómo funciona un módulo desconocido, y un subagente de pruebas para escribir y ejecutar la suite de verificación. Cada subagente consume una gran cantidad de razonamiento intermedio que el líder nunca tiene que ver. Lo que vuelve es un resumen: "así funciona el módulo" y "estos son los resultados". El líder se mantiene limpio, orientado y eficaz.
+
+Los subagentes interactúan con las habilidades (a menudo existen para aplicar una en profundidad), con el contexto (reciben una porción enfocada, no el mundo entero) y con el agente líder a través de una entrega estrecha y bien definida. Bien usados, son la forma en que un sistema escala más allá de lo que cualquier agente individual podría sostener en su cabeza.
+
+---
+
+## Habilidades: capacidad que puedes reutilizar
+
+Una habilidad es una capacidad empaquetada y reutilizable: un procedimiento definido, con el conocimiento y los pasos para ejecutarlo, que cualquier agente puede aplicar. Si un prompt es una solicitud puntual, una habilidad es una competencia que el sistema conserva.
+
+Esta es la diferencia entre explicar cómo hacer algo cada vez y enseñarlo una sola vez. Sin habilidades, la experiencia vive en quien escribió el mejor prompt, y se evapora cuando la conversación se cierra. Con habilidades, esa experiencia se convierte en un activo duradero y versionado. "Cómo clasificamos un ticket de soporte", "cómo damos formato a un informe de cumplimiento", "cómo ejecutamos nuestra lista de despliegue": cada una se convierte en una habilidad que un agente invoca en vez de un proceso que improvisa.
+
+El poder de las habilidades es la composición. La misma habilidad puede ser aplicada por muchos agentes y muchos subagentes. Una sola habilidad puede mejorarse una vez y elevar de inmediato la calidad de todos los flujos que la usan. Las habilidades interactúan con los agentes (que deciden cuándo aplicarlas), con el contexto (que aporta los detalles sobre los que opera la habilidad) y con la memoria (que puede refinar con el tiempo cómo se usa una habilidad).
+
+El error es tratar las habilidades como scripts desechables en vez de activos gobernados y compartidos. Cuando las habilidades están dispersas y son personales, obtienes la misma fragmentación que los gestores de paquetes resolvieron en su día para las dependencias de código: todos reinventan la misma capacidad de forma ligeramente distinta, y la calidad es una lotería.
+
+---
+
+## Contexto: conciencia situacional en el momento
+
+El contexto es la información relevante en este momento. No todo lo que el sistema sabe, solo lo que importa para la tarea que tiene enfrente: el documento actual, los registros relevantes, el estado de la conversación, los datos recuperados para esta decisión específica.
+
+El contexto es el bloque más subestimado de todo el modelo, y la causa de la mayoría de los resultados decepcionantes. Un modelo sin contexto es brillante y ciego. Razona maravillosamente sobre nada en particular. El salto de calidad casi nunca viene de un mejor prompt. Viene de poner la información correcta frente al modelo en el momento correcto. En la empresa esto tiene un nombre: fundamentación (grounding). Conectas el sistema a tus datos, recuperas los pasajes que importan y dejas que el modelo razone sobre la realidad en vez de sobre su entrenamiento genérico.
+
+Pero el contexto tiene un filo, y corta en sentido contrario al que la gente supone. El instinto es meterlo todo, bajo la teoría de que más información es más seguro. No lo es. Un contexto sobrecargado entierra la señal que importa bajo el ruido, y la calidad cae. La disciplina del contexto es la curaduría: recuperar exactamente lo relevante y nada más. El contexto interactúa con la memoria (que decide qué vale la pena traer al momento), con los prompts (a los que fundamenta) y con los agentes (que actúan sobre él).
+
+Esta es la regla que vale la pena memorizar: la mayoría de los problemas de "la IA dio una mala respuesta" no son fallos de razonamiento. Son fallos de contexto.
+
+---
+
+## Memoria: aprender a lo largo del tiempo
+
+La memoria es información que persiste a lo largo del tiempo, más allá de una sola tarea o conversación. Si el contexto es lo que está sobre el escritorio ahora mismo, la memoria es el archivero, el conocimiento institucional, la relación que se profundiza con cada interacción.
+
+Sin memoria, cada sesión empieza desde cero. El sistema te conoce permanentemente por primera vez, reaprende tus convenciones, repite preguntas que ya respondiste, olvida la decisión que te ayudó a tomar ayer. Es inteligencia con amnesia, y pone un techo al valor de todo lo demás. Con memoria, el sistema se acumula. Recuerda tus preferencias, tus decisiones pasadas y las razones detrás de ellas, las correcciones que hiciste, la forma en que tu dominio realmente funciona.
+
+La memoria y el contexto son socios, no sinónimos, y confundirlos es un error común y costoso. La memoria es el almacén duradero. El contexto es el conjunto de trabajo que se extrae de ella para la tarea actual. La memoria hidrata el contexto: decide qué del registro de largo plazo vale la pena traer al momento presente. Los agentes escriben en la memoria a medida que trabajan, de modo que el sistema que atienda una tarea la próxima semana sea más inteligente que el que la atendió hoy. Ese ciclo de retroalimentación, escribir y recordar, es lo que separa una herramienta que operas de un sistema que aprende.
+
+El error es saltarse la memoria por completo porque es más difícil de construir que un prompt. Hay equipos que lanzan sistemas sin estado y luego se preguntan por qué la experiencia se siente superficial y por qué los usuarios nunca desarrollan confianza. La confianza se construye sobre ser recordado.
+
+---
+
+## Notebooks: el banco de trabajo compartido
+
+Un notebook es un espacio de trabajo compartido e iterativo donde humanos y agentes piensan juntos. No es un registro de chat que se va hacia arriba y no es software terminado. Es el banco donde el trabajo se compone, se ejecuta, se inspecciona y se refina, con el razonamiento a la vista.
+
+El papel del notebook es hacer el proceso legible. En un chat, la conversación se desvanece hacia arriba y los pasos se difuminan. En un notebook, la intención, el código, los resultados y los comentarios conviven lado a lado como artefactos duraderos que puedes volver a ejecutar, ajustar y construir encima. Aquí es donde el humano permanece en el ciclo, no como espectador que mira a un agente trabajar, sino como colaborador que puede inspeccionar un paso, cambiar una suposición y ejecutarlo de nuevo. Es el hábitat natural de los patrones de colaboración que describí en [Humanos y agentes](/blog/humans-and-agents-collaboration-patterns).
+
+Los notebooks interactúan con casi todo: los agentes trabajan dentro de ellos, las habilidades se aplican y se prueban en ellos, el contexto se carga y se examina en ellos, y los resultados que se validan pueden promoverse a habilidades duraderas o flujos de producción. El notebook es donde la experimentación se convierte en entendimiento.
+
+El error es dejar morir el trabajo valioso en el notebook. Un notebook es para iterar, no para la permanencia. Cuando algo que descubriste ahí resulta útil, debería graduarse: a una habilidad, a las instrucciones de un agente, al proyecto mismo. Un notebook lleno de ideas que nunca se promueven es un banco de trabajo lleno de piezas terminadas que nadie instala.
+
+---
+
+## Proyectos: el límite que lo convierte en un sistema
+
+Un proyecto es la misión, el límite y los datos fundamentados que mantienen unido todo lo demás. Es el contenedor. Cada uno de los otros bloques, los prompts, los agentes, los subagentes, las habilidades, el contexto, la memoria, los notebooks, vive dentro de un proyecto y recibe su sentido de él.
+
+El proyecto es lo que marca la diferencia entre un asistente ingenioso y un sistema en el que se puede confiar para trabajo real. Define el alcance: qué está dentro de los límites y qué no. Define la fundamentación: a qué datos está conectado el sistema y sobre cuáles tiene permiso para razonar. Define los activos compartidos: los agentes y las habilidades disponibles, la memoria que se acumula, las convenciones que todos siguen. Un proyecto convierte un montón de partes capaces en un todo coherente con un propósito. Este es el espíritu de construir software para sistemas, no para sesiones, que desgrané en [Diseñar software para un mundo agéntico](/blog/designing-software-agent-first-world).
+
+En la práctica, el proyecto es donde vive la gobernanza, y la gobernanza es lo que hace posible la adopción empresarial. Los límites no son burocracia. Son lo que te permite darle a un sistema acceso a datos reales y acciones reales sin perder el control de ninguno de los dos. El proyecto es donde decides qué tiene permitido saber el sistema, qué tiene permitido hacer y de qué es responsable.
+
+El error es operar sin uno: agentes sin límite, tomando de todo, fundamentados en nada en particular, responsables ante ningún alcance definido. Eso no es un sistema. Es una vulnerabilidad con buena gramática.
+
+---
+
+## La orquestación es el punto central
+
+Esta es la tesis que todo el modelo busca entregar: el valor no está en los bloques. Está en cómo se coordinan. Un sistema de inteligencia no son ocho funcionalidades atornilladas juntas. Es un único flujo orquestado.
+
+Mira las partes moverse juntas en un solo escenario empresarial. Un equipo necesita preparar un informe para la renovación de una cuenta.
+
+1. El **proyecto** prepara el escenario. Es el espacio de trabajo de la cuenta, fundamentado en los datos de uso del cliente, su historial de soporte y los manuales del equipo. Define qué está dentro del alcance y qué puede tocar el sistema.
+2. Un **prompt** declara la intención: produce un informe de renovación y marca cualquier riesgo que requiera la decisión de un líder.
+3. Un **agente** toma posesión de ese resultado. No solo responde. Planifica el trabajo.
+4. Delega en **subagentes**: uno extrae y analiza las tendencias de uso, otro revisa el historial de soporte en busca de fricción no resuelta. Cada uno trabaja en su propio espacio enfocado y devuelve un resultado limpio.
+5. A lo largo del proceso, los agentes aplican **habilidades**: la forma estándar en que la organización evalúa la salud de una cuenta y redacta un informe ejecutivo, aplicada de forma consistente en vez de improvisada.
+6. Todo está fundamentado en el **contexto**: los datos reales de esta cuenta específica, recuperados con precisión, no una plantilla genérica.
+7. El trabajo recurre a la **memoria**: lo que el equipo aprendió sobre esta cuenta el trimestre pasado, las preocupaciones planteadas antes, los compromisos asumidos. Y escribe de vuelta, para que el próximo trimestre empiece con ventaja.
+8. Una persona revisa y refina en un **notebook**, ajustando el énfasis, corrigiendo un matiz, aprobando el resultado.
+
+Ningún bloque por sí solo hizo nada milagroso. El resultado (un informe fundamentado y confiable producido en una fracción del tiempo habitual) vino de la coordinación. Quita cualquiera de los bloques y se degrada: sin memoria, olvida la relación; sin contexto, alucina los detalles; sin subagentes, el líder se ahoga en la profundidad; sin proyecto, no tiene siquiera derecho a los datos.
+
+Este es el cambio de mentalidad que exige el dominio. Deja de preguntar "¿qué puede hacer el modelo?" Empieza a preguntar "¿cómo orquesto estos bloques en un flujo que produzca el resultado?" La primera pregunta tiene más o menos la misma respuesta para todos. La segunda es donde se construyen los sistemas reales, y la ventaja real.
+
+---
+
+## Los errores que mantienen los sistemas en la superficie
+
+Los fracasos en este campo son notablemente consistentes. Casi todos vienen de sobreinvertir en un bloque mientras se descuida el sistema.
+
+- **Idolatrar el prompt.** Tratar la redacción del prompt como la habilidad maestra mientras se ignora el contexto en el que se ejecuta y la memoria que podría usar. Un prompt perfecto sobre un contexto vacío sigue siendo una respuesta vacía.
+- **Confundir el modelo con el sistema.** Creer que un modelo más capaz elimina la necesidad de arquitectura. Hace lo contrario. Un motor más potente hace que la buena orquestación valga más, no menos.
+- **Construir el monolito.** Un agente desbordado al que se le pide hacer todo, en vez de un líder que delega en subagentes enfocados. Luce bien en demo y falla bajo carga real.
+- **Saltarse la memoria.** Lanzar sistemas sin estado que conocen al usuario por primera vez en cada sesión, y luego preguntarse por qué nunca se forma la confianza.
+- **Matar de hambre o inundar el contexto.** Darle al modelo nada en qué fundamentarse, o enterrar la señal bajo todo lo que pudiste encontrar. Ambos producen malas respuestas por razones opuestas.
+- **Tratar las habilidades como trabajo borrador.** Dejar que la capacidad viva en prompts personales en vez de activos compartidos y versionados, de modo que la calidad se vuelve una lotería y nada se acumula.
+- **Operar sin un proyecto.** Sin límite, sin fundamentación, sin responsabilidad. Capaz, conectado y sin gobernar no es una funcionalidad. Es una exposición.
+
+Fíjate en el patrón. Cada uno de estos es un fallo de coordinación disfrazado de problema de capacidad. El modelo rara vez es el cuello de botella. La arquitectura a su alrededor casi siempre lo es.
+
+---
+
+## Cómo se ve el dominio de aquí en adelante
+
+La primera era de la IA generativa premió al prompt ingenioso. Esa era está terminando. La redacción que se sentía como una ventaja competitiva se está volviendo lo mínimo, porque los modelos están absorbiendo ese ingenio en sus comportamientos por defecto.
+
+La próxima era premia una habilidad distinta: la capacidad de componer. Las personas y las organizaciones que tomen la delantera serán las que piensen como arquitectos de inteligencia, las que diseñen cómo encajan agentes, subagentes, habilidades, contexto, memoria, prompts, notebooks y proyectos en sistemas que aprenden, se especializan y se mantienen fundamentados en la realidad. Las aplicaciones que definan la próxima década no nacerán de un prompt. Se ensamblarán, con el mismo rigor que aplicamos a cualquier sistema de software serio.
+
+Así que esta es la conclusión que vale la pena conservar. La IA generativa no es un chatbot que consultas. Es un sistema que arquitectas. El dominio no es conocer las palabras mágicas. Es conocer los bloques de construcción, y saber cómo hacerlos funcionar como uno solo. El modelo es la parte fácil. El sistema es el juego completo.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-06-22-MasteringGenerativeAI.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-06-22-MasteringGenerativeAI.mdx
@@ -1,0 +1,213 @@
+---
+title: "Dominar a IA generativa: a arquitetura de um sistema de inteligência"
+description: "A IA generativa não é um chatbot. É um sistema. Este é um modelo mental de como oito blocos de construção (agentes, subagentes, habilidades, contexto, memória, prompts, notebooks e projetos) trabalham juntos para transformar um modelo capaz em inteligência real e escalável."
+slug: mastering-generative-ai-systems-of-intelligence
+authors: [dsanchezcr]
+tags: [AI, Generative AI, Agentic AI, Software Architecture, Enterprise AI, Software Engineering]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-22-mastering-generative-ai/mastering-generative-ai.jpg
+date: 2026-06-22T10:00
+---
+
+# Dominar a IA generativa: a arquitetura de um sistema de inteligência
+
+_Oito blocos de construção que transformam um modelo capaz em um sistema que entrega trabalho real: agentes, subagentes, habilidades, contexto, memória, prompts, notebooks e projetos._
+
+A maioria acredita que está usando IA generativa quando abre uma janela de chat e digita uma pergunta. Está usando a parte menos interessante de tudo isso. O chat é a porta de entrada, não a casa.
+
+{/* truncate */}
+
+O reenquadramento que importa é este: um modelo que responde perguntas é uma funcionalidade. Um sistema que persegue resultados é uma categoria diferente. O primeiro é um chatbot. O segundo é um **sistema de inteligência**, e a diferença entre os dois não são modelos maiores. É arquitetura.
+
+A capacidade bruta está virando commodity em alta velocidade. Qualquer modelo sério já escreve código, resume um documento e rascunha um plano. Não é mais ali que mora a vantagem. A vantagem mora em como você monta essa capacidade em algo que lembra, se especializa, se fundamenta nos seus dados e coordena o próprio trabalho. Essa montagem tem partes, e as partes têm nome. Este artigo é o modelo mental que as conecta.
+
+---
+
+## O marco unificador: a inteligência como sistema operacional
+
+Pare de imaginar um gênio dentro de uma caixa. Imagine uma equipe de alto desempenho trabalhando dentro de um espaço de trabalho bem definido.
+
+Uma equipe tem pessoas donas dos resultados, especialistas a quem recorre quando preciso, manuais compartilhados que todos seguem, consciência da situação à sua frente, conhecimento institucional que sobrevive à rotatividade, atribuições claras, uma bancada onde as ideias são testadas e uma missão com limites. Um sistema de inteligência tem exatamente as mesmas partes. Só damos a elas nomes diferentes.
+
+Este é o mapa completo:
+
+| Bloco de construção | O que é | Sua função no sistema |
+|---|---|---|
+| **Prompt** | Uma declaração estruturada de intenção | Coloca o trabalho em movimento |
+| **Agente** | Uma unidade autônoma dona de um resultado | Decide, age e verifica |
+| **Subagente** | Um especialista delimitado a quem um agente delega | Traz profundidade sem poluir o fluxo principal |
+| **Habilidade** | Uma capacidade empacotada e reutilizável | Codifica a experiência para aplicá-la de forma consistente |
+| **Contexto** | A informação relevante neste momento | Fundamenta o trabalho na situação atual |
+| **Memória** | Informação que persiste ao longo do tempo | Permite que o sistema aprenda em vez de recomeçar |
+| **Notebook** | Um espaço de trabalho compartilhado e iterativo | Onde humanos e agentes pensam juntos |
+| **Projeto** | A missão, o limite e os dados fundamentados | Contém tudo e define o que está no escopo |
+
+O diagrama abaixo é o modelo que convém manter na cabeça. Leia-o como um único espaço de trabalho (o projeto) dentro do qual a intenção flui para um agente, o agente delega e aplica habilidades, enquanto o contexto e a memória alimentam e registram o trabalho de forma contínua.
+
+```mermaid
+flowchart TD
+    subgraph PROJETO["PROJETO: a missão, o limite, os dados fundamentados"]
+        P["PROMPT: a intenção que inicia o trabalho"]
+        A["AGENTE: dono do resultado"]
+        SA["SUBAGENTES: especialistas a quem delega"]
+        SK["HABILIDADES: capacidades duradouras e reutilizáveis"]
+        C["CONTEXTO: o que importa agora"]
+        M[("MEMÓRIA: o que persiste no tempo")]
+        N["NOTEBOOK: a bancada compartilhada"]
+
+        P --> A
+        A -->|delega para| SA
+        A -->|aplica| SK
+        SA -->|aplica| SK
+        C -.->|fundamenta| A
+        M -.->|hidrata| C
+        A -.->|escreve em| M
+        N <-.->|iteram juntos| A
+    end
+```
+
+Agora vamos percorrer cada bloco: o que é, o papel que cumpre e como interage com os demais. A ordem é uma narrativa, da faísca da intenção até o limite que contém todo o sistema.
+
+---
+
+## Prompts: intenção, não encantamento
+
+Um prompt é uma declaração de intenção. Essa é a definição inteira, e boa parte da confusão nesta área vem de esquecê-la.
+
+O equívoco popular é que escrever prompts é um saco de truques: frases mágicas, aberturas de interpretação de papéis e ameaças que supostamente arrancam respostas melhores do modelo. Isso é folclore. Os prompts que se sustentam são os que comunicam a intenção com precisão: o objetivo, as restrições, as entradas, a definição de pronto. Um bom prompt parece menos um feitiço e mais uma pequena especificação. Desenvolvi esse argumento a fundo em [De prompts a especificações](/blog/from-prompts-to-specifications), e é a base sobre a qual tudo o mais se apoia.
+
+Este é o papel que um prompt realmente cumpre: é a interface entre a intenção humana e a ação da máquina. Em um sistema de inteligência, um prompt raramente viaja sozinho. Chega carregando contexto, é interpretado por um agente e é moldado pela memória e pelas habilidades disponíveis no projeto. As mesmas palavras produzem resultados radicalmente diferentes conforme o que as cerca.
+
+O erro a evitar é tratar o prompt como se fosse o sistema inteiro. Há equipes que investem semanas ajustando prompts enquanto ignoram o contexto em que esse prompt é executado e a memória da qual ele poderia tomar. Isso é otimizar a pergunta enquanto se mata de fome a resposta. Um prompt preciso sem contexto é uma pergunta precisa gritada em uma sala vazia.
+
+---
+
+## Agentes: a unidade dona de um resultado
+
+Um agente é uma unidade autônoma dona de um resultado. A palavra-chave é *dona*. Um chatbot responde a um turno. Um agente persegue um objetivo: planeja, age, observa os resultados, corrige o rumo e decide quando o trabalho está realmente concluído.
+
+Este é o salto de responder para realizar. Peça a um modelo que "resuma este relatório" e você recebe texto. Dê a um agente o objetivo "produza o relatório semanal de riscos e sinalize qualquer coisa que exija uma decisão executiva" e ele precisa recuperar os documentos certos, aplicar julgamento, usar ferramentas e montar um resultado que atenda a um padrão. O agente é o ator do sistema, aquilo que transforma intenção em trabalho concluído.
+
+Um agente interage com tudo o mais: lê o **contexto** para entender a situação, recorre à **memória** para não reaprender o que já sabe, aplica **habilidades** para executar passos especializados de forma confiável e delega a **subagentes** quando uma tarefa exige uma profundidade que ele não deveria lidar em linha. O prompt define sua direção. O projeto traça seu limite.
+
+A falha típica aqui é o monólito: um agente gigante com um conjunto de instruções inchado a quem se pede fazer tudo. Funciona em demos e desmorona em produção, porque uma única janela de contexto não consegue sustentar um processo de negócio inteiro sem perder o fio. Os sistemas reais se decompõem. E é exatamente por isso que existem os subagentes.
+
+---
+
+## Subagentes: a delegação como princípio de design
+
+Um subagente é um especialista delimitado que um agente chama para resolver uma tarefa bem definida. Se o agente é o líder, os subagentes são os especialistas que ele convoca para uma pergunta específica e depois libera.
+
+A razão pela qual os subagentes importam não é organização prolixa. É uma restrição dura de como esses sistemas funcionam: a atenção e o contexto são finitos. Quando um agente líder tenta pesquisar, escrever, testar e revisar dentro de uma única conversa, cada uma dessas preocupações compete pelo mesmo espaço de trabalho limitado, e a qualidade se degrada. Delegar uma tarefa autocontida a um subagente dá a essa tarefa seu próprio espaço novo para trabalhar. O subagente se aprofunda, devolve um resultado limpo e o agente líder se mantém focado no resultado de que é dono. Explorei como compor equipes desses agentes em [Construa sua equipe de agentes de IA](/blog/building-your-ai-agent-team).
+
+Pense em um fluxo de desenvolvimento. O agente líder está implementando uma funcionalidade. Ele despacha um subagente de exploração para mapear como funciona um módulo desconhecido, e um subagente de testes para escrever e executar a suíte de verificação. Cada subagente consome uma grande quantidade de raciocínio intermediário que o líder nunca precisa ver. O que volta é um resumo: "é assim que o módulo funciona" e "estes são os resultados". O líder se mantém limpo, orientado e eficaz.
+
+Os subagentes interagem com as habilidades (muitas vezes existem para aplicar uma em profundidade), com o contexto (recebem uma fatia focada, não o mundo inteiro) e com o agente líder por meio de uma entrega estreita e bem definida. Bem usados, são a forma como um sistema escala além do que qualquer agente individual conseguiria sustentar na cabeça.
+
+---
+
+## Habilidades: capacidade que você pode reutilizar
+
+Uma habilidade é uma capacidade empacotada e reutilizável: um procedimento definido, com o conhecimento e os passos para executá-lo, que qualquer agente pode aplicar. Se um prompt é um pedido pontual, uma habilidade é uma competência que o sistema conserva.
+
+Esta é a diferença entre explicar como fazer algo toda vez e ensinar uma única vez. Sem habilidades, a experiência vive em quem escreveu o melhor prompt, e evapora quando a conversa se fecha. Com habilidades, essa experiência se torna um ativo duradouro e versionado. "Como classificamos um ticket de suporte", "como formatamos um relatório de conformidade", "como executamos nossa lista de implantação": cada uma se torna uma habilidade que um agente invoca em vez de um processo que ele improvisa.
+
+O poder das habilidades é a composição. A mesma habilidade pode ser aplicada por muitos agentes e muitos subagentes. Uma única habilidade pode ser melhorada uma vez e elevar imediatamente a qualidade de todos os fluxos que a usam. As habilidades interagem com os agentes (que decidem quando aplicá-las), com o contexto (que fornece os detalhes sobre os quais a habilidade opera) e com a memória (que pode refinar com o tempo como uma habilidade é usada).
+
+O erro é tratar as habilidades como scripts descartáveis em vez de ativos governados e compartilhados. Quando as habilidades estão dispersas e são pessoais, você obtém a mesma fragmentação que os gerenciadores de pacotes resolveram um dia para as dependências de código: todos reinventam a mesma capacidade de forma ligeiramente diferente, e a qualidade é uma loteria.
+
+---
+
+## Contexto: consciência situacional no momento
+
+O contexto é a informação relevante neste momento. Não tudo o que o sistema sabe, apenas o que importa para a tarefa à sua frente: o documento atual, os registros relevantes, o estado da conversa, os dados recuperados para esta decisão específica.
+
+O contexto é o bloco mais subestimado de todo o modelo, e a causa da maioria dos resultados decepcionantes. Um modelo sem contexto é brilhante e cego. Raciocina maravilhosamente sobre nada em particular. O salto de qualidade quase nunca vem de um prompt melhor. Vem de colocar a informação certa diante do modelo no momento certo. Na empresa isso tem um nome: fundamentação (grounding). Você conecta o sistema aos seus dados, recupera os trechos que importam e deixa o modelo raciocinar sobre a realidade em vez de sobre seu treinamento genérico.
+
+Mas o contexto tem um fio, e ele corta no sentido contrário ao que as pessoas supõem. O instinto é colocar tudo, sob a teoria de que mais informação é mais seguro. Não é. Um contexto sobrecarregado enterra o sinal que importa sob o ruído, e a qualidade cai. A disciplina do contexto é a curadoria: recuperar exatamente o relevante e nada mais. O contexto interage com a memória (que decide o que vale a pena trazer ao momento), com os prompts (aos quais ele fundamenta) e com os agentes (que agem sobre ele).
+
+Esta é a regra que vale a pena memorizar: a maioria dos problemas de "a IA deu uma resposta ruim" não são falhas de raciocínio. São falhas de contexto.
+
+---
+
+## Memória: aprender ao longo do tempo
+
+A memória é informação que persiste ao longo do tempo, além de uma única tarefa ou conversa. Se o contexto é o que está sobre a mesa agora, a memória é o arquivo, o conhecimento institucional, a relação que se aprofunda a cada interação.
+
+Sem memória, cada sessão começa do zero. O sistema te conhece permanentemente pela primeira vez, reaprende suas convenções, repete perguntas que você já respondeu, esquece a decisão que ajudou você a tomar ontem. É inteligência com amnésia, e coloca um teto no valor de tudo o mais. Com memória, o sistema se acumula. Lembra suas preferências, suas decisões passadas e as razões por trás delas, as correções que você fez, a forma como seu domínio realmente funciona.
+
+A memória e o contexto são parceiros, não sinônimos, e confundi-los é um erro comum e custoso. A memória é o armazém duradouro. O contexto é o conjunto de trabalho extraído dela para a tarefa atual. A memória hidrata o contexto: decide o que do registro de longo prazo vale a pena trazer ao momento presente. Os agentes escrevem na memória à medida que trabalham, de modo que o sistema que atender a uma tarefa na próxima semana seja mais inteligente que o que a atendeu hoje. Esse ciclo de retroalimentação, escrever e lembrar, é o que separa uma ferramenta que você opera de um sistema que aprende.
+
+O erro é pular a memória por completo porque ela é mais difícil de construir que um prompt. Há equipes que lançam sistemas sem estado e depois se perguntam por que a experiência parece superficial e por que os usuários nunca desenvolvem confiança. A confiança se constrói sobre ser lembrado.
+
+---
+
+## Notebooks: a bancada compartilhada
+
+Um notebook é um espaço de trabalho compartilhado e iterativo onde humanos e agentes pensam juntos. Não é um registro de chat que rola para cima e não é software acabado. É a bancada onde o trabalho é composto, executado, inspecionado e refinado, com o raciocínio à vista.
+
+O papel do notebook é tornar o processo legível. Em um chat, a conversa se desvanece para cima e os passos se misturam. Em um notebook, a intenção, o código, os resultados e os comentários convivem lado a lado como artefatos duradouros que você pode reexecutar, ajustar e construir em cima. Aqui é onde o humano permanece no ciclo, não como espectador que assiste a um agente trabalhar, mas como colaborador que pode inspecionar um passo, mudar uma suposição e executá-lo de novo. É o habitat natural dos padrões de colaboração que descrevi em [Humanos e agentes](/blog/humans-and-agents-collaboration-patterns).
+
+Os notebooks interagem com quase tudo: os agentes trabalham dentro deles, as habilidades são aplicadas e testadas neles, o contexto é carregado e examinado neles, e os resultados que se comprovam podem ser promovidos a habilidades duradouras ou fluxos de produção. O notebook é onde a experimentação se torna entendimento.
+
+O erro é deixar o trabalho valioso morrer no notebook. Um notebook é para iterar, não para a permanência. Quando algo que você descobriu ali se mostra útil, deveria se formar: em uma habilidade, nas instruções de um agente, no próprio projeto. Um notebook cheio de ideias que nunca são promovidas é uma bancada cheia de peças prontas que ninguém instala.
+
+---
+
+## Projetos: o limite que o transforma em um sistema
+
+Um projeto é a missão, o limite e os dados fundamentados que mantêm tudo o mais unido. É o contêiner. Cada um dos outros blocos, os prompts, os agentes, os subagentes, as habilidades, o contexto, a memória, os notebooks, vive dentro de um projeto e recebe seu sentido dele.
+
+O projeto é o que marca a diferença entre um assistente engenhoso e um sistema em que se pode confiar para trabalho real. Define o escopo: o que está dentro dos limites e o que não está. Define a fundamentação: a quais dados o sistema está conectado e sobre quais tem permissão para raciocinar. Define os ativos compartilhados: os agentes e as habilidades disponíveis, a memória que se acumula, as convenções que todos seguem. Um projeto transforma um monte de partes capazes em um todo coerente com um propósito. Este é o espírito de construir software para sistemas, não para sessões, que destrinchei em [Projetar software para um mundo agêntico](/blog/designing-software-agent-first-world).
+
+Na prática, o projeto é onde mora a governança, e a governança é o que torna possível a adoção empresarial. Os limites não são burocracia. São o que permite dar a um sistema acesso a dados reais e ações reais sem perder o controle de nenhum dos dois. O projeto é onde você decide o que o sistema tem permissão para saber, o que tem permissão para fazer e por quê é responsável.
+
+O erro é operar sem um: agentes sem limite, puxando de tudo, fundamentados em nada em particular, responsáveis perante nenhum escopo definido. Isso não é um sistema. É uma vulnerabilidade com boa gramática.
+
+---
+
+## A orquestração é o ponto central
+
+Esta é a tese que todo o modelo busca entregar: o valor não está nos blocos. Está em como eles são coordenados. Um sistema de inteligência não são oito funcionalidades parafusadas juntas. É um único fluxo orquestrado.
+
+Veja as partes se moverem juntas em um único cenário empresarial. Uma equipe precisa preparar um relatório para a renovação de uma conta.
+
+1. O **projeto** prepara o palco. É o espaço de trabalho da conta, fundamentado nos dados de uso do cliente, em seu histórico de suporte e nos manuais da equipe. Define o que está no escopo e o que o sistema pode tocar.
+2. Um **prompt** declara a intenção: produza um relatório de renovação e sinalize qualquer risco que exija a decisão de um líder.
+3. Um **agente** assume a posse desse resultado. Não apenas responde. Ele planeja o trabalho.
+4. Ele delega a **subagentes**: um extrai e analisa as tendências de uso, outro varre o histórico de suporte em busca de atrito não resolvido. Cada um trabalha em seu próprio espaço focado e devolve um resultado limpo.
+5. Ao longo do processo, os agentes aplicam **habilidades**: a forma padrão como a organização avalia a saúde de uma conta e rascunha um relatório executivo, aplicada de forma consistente em vez de improvisada.
+6. Tudo está fundamentado no **contexto**: os dados reais desta conta específica, recuperados com precisão, não um modelo genérico.
+7. O trabalho recorre à **memória**: o que a equipe aprendeu sobre esta conta no trimestre passado, as preocupações levantadas antes, os compromissos assumidos. E escreve de volta, para que o próximo trimestre comece com vantagem.
+8. Uma pessoa revisa e refina em um **notebook**, ajustando a ênfase, corrigindo uma nuance, aprovando o resultado.
+
+Nenhum bloco sozinho fez algo milagroso. O resultado (um relatório fundamentado e confiável produzido em uma fração do tempo habitual) veio da coordenação. Tire qualquer um dos blocos e ele se degrada: sem memória, esquece a relação; sem contexto, alucina os detalhes; sem subagentes, o líder se afoga na profundidade; sem projeto, não tem sequer direito aos dados.
+
+Esta é a mudança de mentalidade que o domínio exige. Pare de perguntar "o que o modelo consegue fazer?" Comece a perguntar "como orquestro esses blocos em um fluxo que produza o resultado?" A primeira pergunta tem mais ou menos a mesma resposta para todos. A segunda é onde se constroem os sistemas reais, e a vantagem real.
+
+---
+
+## Os erros que mantêm os sistemas na superfície
+
+Os fracassos nesta área são notavelmente consistentes. Quase todos vêm de superinvestir em um bloco enquanto se negligencia o sistema.
+
+- **Idolatrar o prompt.** Tratar a redação do prompt como a habilidade mestra enquanto se ignora o contexto em que ele é executado e a memória que ele poderia usar. Um prompt perfeito sobre um contexto vazio continua sendo uma resposta vazia.
+- **Confundir o modelo com o sistema.** Acreditar que um modelo mais capaz elimina a necessidade de arquitetura. Faz o oposto. Um motor mais potente faz a boa orquestração valer mais, não menos.
+- **Construir o monólito.** Um agente inchado a quem se pede fazer tudo, em vez de um líder que delega a subagentes focados. Parece bom em demo e falha sob carga real.
+- **Pular a memória.** Lançar sistemas sem estado que conhecem o usuário pela primeira vez a cada sessão, e depois se perguntar por que a confiança nunca se forma.
+- **Matar de fome ou inundar o contexto.** Dar ao modelo nada em que se fundamentar, ou enterrar o sinal sob tudo o que você conseguiu encontrar. Ambos produzem respostas ruins por razões opostas.
+- **Tratar as habilidades como rascunho.** Deixar a capacidade viver em prompts pessoais em vez de ativos compartilhados e versionados, de modo que a qualidade vira uma loteria e nada se acumula.
+- **Operar sem um projeto.** Sem limite, sem fundamentação, sem responsabilidade. Capaz, conectado e sem governança não é uma funcionalidade. É uma exposição.
+
+Repare no padrão. Cada um destes é uma falha de coordenação disfarçada de problema de capacidade. O modelo raramente é o gargalo. A arquitetura ao seu redor quase sempre é.
+
+---
+
+## Como o domínio se parece daqui em diante
+
+A primeira era da IA generativa premiou o prompt engenhoso. Essa era está terminando. A redação que parecia uma vantagem competitiva está virando o mínimo, porque os modelos estão absorvendo essa engenhosidade em seus comportamentos padrão.
+
+A próxima era premia uma habilidade diferente: a capacidade de compor. As pessoas e as organizações que tomarem a dianteira serão as que pensam como arquitetos de inteligência, as que projetam como agentes, subagentes, habilidades, contexto, memória, prompts, notebooks e projetos se encaixam em sistemas que aprendem, se especializam e se mantêm fundamentados na realidade. As aplicações que definirão a próxima década não nascerão de um prompt. Serão montadas, com o mesmo rigor que aplicamos a qualquer sistema de software sério.
+
+Então esta é a conclusão que vale a pena guardar. A IA generativa não é um chatbot que você consulta. É um sistema que você arquiteta. O domínio não é conhecer as palavras mágicas. É conhecer os blocos de construção, e saber como fazê-los funcionar como um só. O modelo é a parte fácil. O sistema é o jogo inteiro.


### PR DESCRIPTION
Add new blog post 'Mastering Generative AI: The Architecture of a System of Intelligence' (2026-06-22) and Spanish/Portuguese translations. Introduces the eight-block framework (agents, subagents, skills, context, memory, prompts, notebooks, projects) for architecting systems of intelligence. Includes frontmatter (authors, tags, image, slug) and enables comments. Adds localized copies under i18n/es and i18n/pt so the post is available in Spanish and Portuguese.