### PR TITLE
Add reviewer fatigue blog translations

### DIFF
--- a/blog/2026-06-25-ReviewerFatigue.mdx
+++ b/blog/2026-06-25-ReviewerFatigue.mdx
@@ -1,0 +1,225 @@
+---
+title: "Reviewer Fatigue: When Agents Write More Code Than Humans Can Read"
+description: "AI agents now write code faster than humans can review it. As authoring accelerates, the bottleneck shifts to the human in the loop. This post analyzes the cognitive cost of reviewing agent-authored code and offers practical patterns for delegation, agents evaluating agents, and layered gating that protect security and quality without burning out your reviewers."
+slug: reviewer-fatigue-human-in-the-loop-bottleneck
+authors: [dsanchezcr]
+tags: [AI, Agentic AI, Code Review, Software Engineering, DevOps, Developer Productivity, Engineering Leadership]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-25-reviewer-fatigue/reviewer-fatigue.jpg
+date: 2026-06-25T10:00
+---
+
+# Reviewer Fatigue: When Agents Write More Code Than Humans Can Read
+
+## The Bottleneck Moved, and Most Teams Have Not Noticed
+
+For decades, writing code was the expensive part. Reading it was almost free by comparison. A developer spent hours producing a change, and a reviewer spent minutes confirming it. That ratio shaped everything: our tools, our processes, our sense of who was busy and who was waiting.
+
+Agents inverted that ratio. A capable agent now produces a complete branch with code, tests, and documentation in the time it takes to write a thoughtful task description. Authoring became cheap. Reading did not.
+
+{/* truncate */}
+
+![Reviewer Fatigue](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-25-reviewer-fatigue/reviewer-fatigue.jpg)
+
+The result is a quiet pileup. Pull requests arrive faster than any human can absorb them. The queue grows. The reviewer, who used to be the fast part of the loop, is now the slow part. The constraint did not disappear when writing got faster. It simply moved to the one place that did not speed up: the person who has to understand, verify, and take responsibility for the change.
+
+This is reviewer fatigue, and it is the defining bottleneck of agentic software engineering. This post focuses on the human at the end of all those pipelines, and how to keep that person effective when the volume of work coming at them keeps climbing.
+
+---
+
+## The Asymmetry Nobody Budgeted For
+
+Writing and reviewing are not mirror images of the same task. They place very different demands on the brain, and that difference is the root of the problem.
+
+When you write code, you build a mental model as you go. Every decision is yours. You know why a variable exists, why a branch was added, why a dependency was chosen. The context lives in your head because you put it there.
+
+When you review code, you have to reconstruct that mental model from the outside, with none of the original context. You are reverse-engineering intent from artifacts. You have to ask: what was this trying to do, does it actually do that, and what could go wrong that the author did not consider.
+
+Reviewing agent-authored code is harder still, for three reasons:
+
+1. **There is no shared context.** A human author can answer "why did you do this?" in a comment thread. An agent's reasoning, if it exists at all, is often discarded after generation. The reviewer is left with the output and no author to interrogate.
+2. **The code looks confident.** Agent output is fluent, well-formatted, and plausible. It rarely looks wrong. Fluency is not correctness, but it reads like it, and that lowers the reviewer's guard.
+3. **The volume is relentless.** A human author produces a few pull requests a day. A team of agents can produce dozens. The reviewer faces not one demanding task but a continuous stream of them.
+
+The uncomfortable truth: the speed gain from agents is partly an illusion if it just relocates the work from a tired author to a tired reviewer. As I noted when [measuring developer productivity](/blog/measuring-developer-productivity-ai-era), a tool that generates code faster but forces engineers to spend more time reviewing it is not a net win.
+
+---
+
+## The Cognitive Science of Reviewer Fatigue
+
+To design good solutions, it helps to understand exactly what is wearing reviewers down. Four well-documented cognitive effects compound under high-volume agent review.
+
+### Cognitive Load
+
+Working memory is small. Reviewing a change means holding the affected code, the surrounding system, the requirements, and the possible failure modes in your head at once. Each pull request resets that load. A reviewer who processes ten agent pull requests in a row is not doing one hard task ten times. They are repeatedly loading and unloading entire mental models, which is far more taxing than the line count suggests.
+
+### Attention Residue
+
+When you switch from one task to another, part of your attention stays behind on the previous task. Reviewers who context-switch between many small pull requests carry residue from each one into the next. The fifth review of the day is conducted with a fraction of the focus available for the first. The work looks the same on paper; the quality of attention is not.
+
+### Automation Bias
+
+Humans tend to trust automated output more than they should, especially when it is fluent and usually correct. After approving twenty agent pull requests that were fine, the reviewer's prior shifts toward "this is probably fine too." The twenty-first, the one with the subtle authorization flaw, sails through. This is the same dynamic I discussed in [security and compliance for agentic workflows](/blog/security-compliance-agentic-workflows): the dangerous defect is the one that arrives wrapped in the same confident packaging as everything that came before it.
+
+### Vigilance Decrement
+
+Sustained attention degrades over time. This is a measured effect in any task that requires watching for rare problems. Code review is exactly such a task: most lines are fine, and the reviewer is hunting for the few that are not. The longer the session, the more the detection rate falls. High agent volume turns review into a long vigilance task, which is precisely the condition under which human attention is least reliable.
+
+Put these four together and you get a clear conclusion: **telling reviewers to "just review more carefully" is not a strategy.** It asks tired people to fight their own neurology at scale. The fix is not more human willpower. It is a system that reduces what reaches the human, pre-qualifies what does, and protects the attention of the reviewer for the decisions that genuinely need a person.
+
+---
+
+## Principle: Make the Human the Last Line, Not the Only Line
+
+In a healthy agentic workflow, a human reviewer should be the final checkpoint, not the first filter. Everything that can be checked mechanically or by another agent should be checked before a person ever looks at the change. By the time a pull request reaches a human, three things should already be true:
+
+1. It has passed every deterministic check (build, tests, lint, security scan, policy).
+2. It has been reviewed by at least one agent reviewer that did not write it.
+3. It has been routed by risk, so the human's effort matches the stakes.
+
+The rest of this post covers how to build that system: delegation patterns that shape the input, agents that review other agents, and gating architectures that route work by risk.
+
+---
+
+## Patterns for Delegation
+
+Delegation is not just "give the agent a task." Done well, it shapes the work so that what comes back is review-ready. The goal is fewer, larger-context, better-explained changes rather than a flood of opaque ones.
+
+| Pattern | What It Does | Why It Reduces Fatigue |
+|---|---|---|
+| **Spec-first delegation** | Give the agent a written specification with acceptance criteria before it writes code | The reviewer checks output against a known intent instead of guessing what the change was for |
+| **Bounded scope** | Constrain each task to a single concern or module | Smaller mental model per review; less context to reconstruct |
+| **Self-documenting output** | Require the agent to produce a change summary, rationale, and a list of risks it considered | The reviewer starts with the author's reasoning instead of an empty context |
+| **Batch by theme, not by time** | Group related changes into one coherent pull request rather than many trickling in | Fewer context switches; less attention residue |
+| **Test-evidence required** | Require the agent to attach test results and explain what each test verifies | The reviewer evaluates evidence, not just claims of coverage |
+| **Reversibility by default** | Prefer changes behind flags or in isolated modules | Lower stakes per review means the human can move faster with confidence |
+
+The spec-first pattern is the highest-leverage of these. As I argued in [from prompts to specifications](/blog/from-prompts-to-specifications), a durable, versioned specification gives the reviewer a fixed reference point. Review then becomes a comparison ("does this match the spec?") rather than an open-ended investigation ("what is this and is it correct?"). That single change transforms the cognitive nature of the task from reconstruction to verification, which is far less draining.
+
+A practical rule: **if a change cannot be explained in a short summary, it is too large to review well.** Use that as a delegation constraint, not just a review complaint.
+
+---
+
+## Agents Evaluating Other Agents
+
+If the volume problem comes from agents, part of the solution comes from agents too. An agent that did not write the code can serve as the first reviewer, catching a large share of issues before a human spends any attention at all.
+
+This is not about replacing human judgment. It is about filtering, so that human judgment is spent where it matters. A few patterns work well in practice.
+
+### The Reviewer Agent
+
+A dedicated reviewer agent reads the change with a different objective than the author. Where the author optimized for "make it work," the reviewer optimizes for "find what is wrong." Custom agents make this concrete: as I described in [building your AI agent team](/blog/building-your-ai-agent-team), you can define a `Security Reviewer` agent that enforces your policies, checks for common vulnerability classes, and validates input handling before any code reaches a person.
+
+### Adversarial Review
+
+Author and reviewer should not be the same agent, and ideally not the same model configuration. An agent reviewing its own output inherits its own blind spots. A separate reviewer agent, given the specification and the diff but not the author's reasoning, approaches the change cold and is more likely to notice gaps. This separation of author and critic is the agentic version of "do not review your own pull request."
+
+### Specialized Review Agents
+
+Different concerns benefit from different reviewers. Rather than one agent that checks everything shallowly, a set of focused agents each check one dimension deeply.
+
+| Review Agent | Focus | Example Checks |
+|---|---|---|
+| **Security reviewer** | Vulnerability classes and trust boundaries | Input validation, authn/authz gaps, secret handling, injection risks |
+| **Architecture reviewer** | Fit with existing patterns | Layering, dependency direction, naming and structure conventions |
+| **Test reviewer** | Quality of verification, not just coverage | Meaningful assertions, edge cases, tests that actually exercise the change |
+| **Dependency reviewer** | Supply chain integrity | New packages, version pins, packages that do not exist in any registry |
+| **Performance reviewer** | Cost and latency implications | N+1 queries, unbounded loops, allocations in hot paths |
+
+### The Trap to Avoid
+
+Agent reviewers can produce automation bias of their own. If a reviewer agent approves a change, a human may rubber-stamp it precisely because an agent already looked. Guard against this by treating agent review as a filter that removes obvious problems, not as an endorsement that ends scrutiny. The agent reviewer reduces volume and surfaces concerns; the human still owns the decision on anything the system flags as high risk.
+
+A useful framing: agent reviewers handle breadth (check everything, every time, without fatigue), and humans handle depth (judgment, context, and accountability on the changes that matter).
+
+---
+
+## Architectures for Security and Quality: Gating by Risk
+
+The final piece is structural. Not every change deserves the same scrutiny, and treating them all equally is how reviewers drown. A risk-based gating architecture routes each change down a path proportional to its potential blast radius.
+
+The principle echoes the shift I described in [CI/CD for the agentic era](/blog/cicd-pipelines-agentic-era): the pipeline stops being a uniform gate and becomes an active, risk-aware router.
+
+```mermaid
+flowchart TD
+    A[Agent produces change] --> B{Deterministic gates}
+    B -- fail --> R[Return to agent with findings]
+    B -- pass --> C[Agent reviewers: security, architecture, tests]
+    C -- concerns found --> R
+    C -- clean --> D{Risk classification}
+    D -- low risk --> E[Auto-merge with audit log]
+    D -- medium risk --> F[Lightweight human review]
+    D -- high risk --> G[Deep human review + second approver]
+    E --> H[Deploy]
+    F --> H
+    G --> H
+```
+
+### Layer 1: Deterministic Gates
+
+These run first and require no human or agent judgment. Build, unit and integration tests, linting, static analysis, secret scanning, dependency vulnerability checks, and policy-as-code. Anything that fails here is returned to the authoring agent automatically, with the findings, so it can fix and resubmit. No human attention is spent on mechanically detectable problems.
+
+### Layer 2: Agent Review
+
+Changes that pass the deterministic gates go to the specialized reviewer agents described above. Their job is to remove the next tier of problems: the ones that need understanding but not necessarily human judgment. Their output is not just pass or fail; it is a structured set of findings and a risk signal that feeds the next layer.
+
+### Layer 3: Risk Classification and Routing
+
+This is the layer most teams are missing. Before a human is involved, classify the change by risk and route accordingly. Useful inputs to the classification:
+
+| Signal | Pushes Risk Up |
+|---|---|
+| **Blast radius** | Touches authentication, payments, data deletion, infrastructure, or public APIs |
+| **Surface** | Changes security boundaries, permissions, or external-facing contracts |
+| **Reversibility** | Hard to roll back, or runs an irreversible migration |
+| **Novelty** | Introduces a new dependency, pattern, or service rather than following an existing one |
+| **Agent confidence** | The authoring or reviewing agent flagged uncertainty or unresolved tradeoffs |
+
+A low-risk change (a copy fix, a well-tested change behind a flag in an isolated module) can be auto-merged with a full audit trail. A medium-risk change gets a lightweight human review. A high-risk change gets deep human review and a second approver. The human's scarce attention is now spent in proportion to the stakes, not spread evenly across a flood.
+
+### Layer 4: The Human Decision
+
+By the time a change reaches a person, the obvious problems are gone, the change is explained, and the risk is labeled. The human is no longer a volume processor. They are a judge, applying context and accountability to the small set of decisions that actually require it. That is the role humans are good at, and the role they should be protected for.
+
+---
+
+## Practical Tips to Overcome Reviewer Fatigue
+
+Beyond the architecture, a set of concrete practices keeps reviewers effective day to day.
+
+- **Cap review session length.** Vigilance degrades over time. Shorter, focused review sessions with breaks detect more problems than marathon queues. Treat review time as a finite, high-value resource, not a background activity squeezed between meetings.
+- **Set a per-reviewer daily limit.** If the queue exceeds what a human can review well, the answer is not a heroic reviewer. It is more agent filtering, better batching, or more auto-merge for low-risk changes. A growing queue is a signal to fix the system, not to push the person harder.
+- **Make agents explain themselves.** Require every agent change to include what it did, why, and what it was unsure about. A reviewer who starts with the author's reasoning spends their energy verifying, not reconstructing.
+- **Separate author and reviewer agents.** Never let the agent that wrote the code be the only one that reviews it. Cold review by a different agent catches what self-review misses.
+- **Rotate reviewers on sensitive areas.** Familiarity breeds automation bias. Fresh eyes on security-critical paths restore vigilance that routine erodes.
+- **Track what slips through.** When a defect escapes review, do a blameless analysis: which gate should have caught it, and why did it not? Feed that back into the deterministic checks and the agent reviewers so the same class of problem is caught automatically next time.
+- **Default to small and reversible.** The easiest review is the one with low stakes. Flags, isolated modules, and incremental changes let reviewers move quickly without carrying risk.
+- **Give reviewers the spec.** A reviewer comparing a change against a clear specification works far faster, and far more reliably, than one inferring intent from the diff alone.
+
+---
+
+## Measuring Whether It Is Working
+
+You cannot manage reviewer fatigue if you cannot see it. A few signals tell you whether the system is healthy or whether the human is silently becoming the bottleneck.
+
+| Signal | What It Tells You | Warning Sign |
+|---|---|---|
+| **Review queue depth and age** | Whether reviewers are keeping up | A growing, aging queue means the system is overloading humans |
+| **Time-in-review per change** | Whether changes are review-ready | Rising review time suggests poor delegation or oversized changes |
+| **Approval-to-incident correlation** | Whether speed is costing quality | Fast approvals followed by incidents signal rubber-stamping |
+| **Defect escape rate** | Whether review is actually catching problems | A rising escape rate means gates or attention are failing |
+| **Reviewer load distribution** | Whether fatigue is concentrated | One or two people carrying the queue is a burnout risk |
+| **Auto-merge rate for low-risk changes** | Whether the system protects human attention | A near-zero rate means humans are reviewing things that do not need them |
+
+The healthiest pattern: most low-risk changes auto-merge safely, agent reviewers absorb the breadth, and human reviewers spend their time on a small number of genuinely consequential decisions with their attention intact. As I noted when [measuring developer productivity](/blog/measuring-developer-productivity-ai-era), the real question is not whether you ship faster, but whether you deliver better outcomes, more safely and sustainably.
+
+---
+
+## Closing Thoughts
+
+Agents made writing code cheap, and in doing so they moved the constraint to the human who has to read it. Reviewer fatigue is the predictable consequence, and it is not solved by asking people to try harder. It is solved by designing a system that respects the limits of human attention.
+
+The shape of that system is consistent: delegate so the input is review-ready, let agents handle the breadth of review, gate by risk so human effort matches the stakes, and protect the reviewer's attention as the scarce resource it is. Keep the human firmly in the loop, but put them at the end of the loop, as the final judgment rather than the first filter.
+
+The teams that thrive in the agentic era will not be the ones that generate the most code. They will be the ones that can review it well, sustainably, without burning out the people whose judgment still matters most.

--- a/i18n/es/docusaurus-plugin-content-blog/2026-06-25-ReviewerFatigue.mdx
+++ b/i18n/es/docusaurus-plugin-content-blog/2026-06-25-ReviewerFatigue.mdx
@@ -1,0 +1,225 @@
+---
+title: "Fatiga del revisor: cuando los agentes escriben más código del que los humanos pueden leer"
+description: "Los agentes de IA ya escriben código más rápido de lo que los humanos pueden revisarlo. A medida que la escritura se acelera, el cuello de botella se traslada al humano dentro del ciclo. Este artículo analiza el costo cognitivo de revisar código generado por agentes y ofrece patrones prácticos de delegación, agentes que evalúan a otros agentes y arquitecturas de control por capas que protegen la seguridad y la calidad sin agotar a tus revisores."
+slug: reviewer-fatigue-human-in-the-loop-bottleneck
+authors: [dsanchezcr]
+tags: [AI, Agentic AI, Code Review, Software Engineering, DevOps, Developer Productivity, Engineering Leadership]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-25-reviewer-fatigue/reviewer-fatigue.jpg
+date: 2026-06-25T10:00
+---
+
+# Fatiga del revisor: cuando los agentes escriben más código del que los humanos pueden leer
+
+## El cuello de botella se movió y la mayoría de los equipos no lo ha notado
+
+Durante décadas, escribir código fue la parte cara. Leerlo era casi gratis en comparación. Un desarrollador pasaba horas produciendo un cambio y un revisor pasaba minutos confirmándolo. Esa proporción dio forma a todo: nuestras herramientas, nuestros procesos y nuestra idea de quién estaba ocupado y quién esperaba.
+
+Los agentes invirtieron esa proporción. Un agente capaz ahora produce una rama completa con código, pruebas y documentación en el tiempo que toma escribir una buena descripción de la tarea. Escribir se volvió barato. Leer no.
+
+{/* truncate */}
+
+![Fatiga del revisor](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-25-reviewer-fatigue/reviewer-fatigue.jpg)
+
+El resultado es una acumulación silenciosa. Los pull requests llegan más rápido de lo que cualquier humano puede absorber. La cola crece. El revisor, que solía ser la parte rápida del ciclo, ahora es la parte lenta. La restricción no desapareció cuando escribir se volvió más rápido. Simplemente se trasladó al único lugar que no aceleró: la persona que tiene que entender, verificar y asumir la responsabilidad del cambio.
+
+Esto es la fatiga del revisor, y es el cuello de botella que define a la ingeniería de software agéntica. Este artículo se centra en el humano al final de todos esos pipelines y en cómo mantener efectiva a esa persona cuando el volumen de trabajo que le llega sigue creciendo.
+
+---
+
+## La asimetría que nadie presupuestó
+
+Escribir y revisar no son imágenes especulares de la misma tarea. Imponen demandas muy distintas al cerebro, y esa diferencia es la raíz del problema.
+
+Cuando escribes código, construyes un modelo mental a medida que avanzas. Cada decisión es tuya. Sabes por qué existe una variable, por qué se agregó una rama, por qué se eligió una dependencia. El contexto vive en tu cabeza porque tú lo pusiste ahí.
+
+Cuando revisas código, tienes que reconstruir ese modelo mental desde afuera, sin nada del contexto original. Estás haciendo ingeniería inversa de la intención a partir de los artefactos. Tienes que preguntar: qué intentaba hacer esto, lo hace de verdad y qué podría salir mal que el autor no consideró.
+
+Revisar código generado por agentes es aún más difícil, por tres razones:
+
+1. **No hay contexto compartido.** Un autor humano puede responder "¿por qué hiciste esto?" en un hilo de comentarios. El razonamiento de un agente, si es que existe, a menudo se descarta después de la generación. Al revisor le queda la salida y ningún autor a quien interrogar.
+2. **El código se ve seguro de sí mismo.** La salida del agente es fluida, bien formateada y plausible. Rara vez parece incorrecta. La fluidez no es corrección, pero se lee como tal, y eso baja la guardia del revisor.
+3. **El volumen es implacable.** Un autor humano produce unos pocos pull requests al día. Un equipo de agentes puede producir docenas. El revisor no enfrenta una tarea exigente, sino un flujo continuo de ellas.
+
+La verdad incómoda: la ganancia de velocidad de los agentes es en parte una ilusión si solo traslada el trabajo de un autor cansado a un revisor cansado. Como señalé al [medir la productividad del desarrollador](/blog/measuring-developer-productivity-ai-era), una herramienta que genera código más rápido pero obliga a los ingenieros a pasar más tiempo revisándolo no es una ganancia neta.
+
+---
+
+## La ciencia cognitiva de la fatiga del revisor
+
+Para diseñar buenas soluciones, ayuda entender exactamente qué está desgastando a los revisores. Cuatro efectos cognitivos bien documentados se acumulan bajo la revisión de alto volumen de agentes.
+
+### Carga cognitiva
+
+La memoria de trabajo es pequeña. Revisar un cambio significa sostener en la cabeza, al mismo tiempo, el código afectado, el sistema circundante, los requisitos y los posibles modos de falla. Cada pull request reinicia esa carga. Un revisor que procesa diez pull requests de agentes seguidos no está haciendo una tarea difícil diez veces. Está cargando y descargando repetidamente modelos mentales completos, lo cual es mucho más exigente de lo que sugiere el número de líneas.
+
+### Residuo de atención
+
+Cuando cambias de una tarea a otra, parte de tu atención se queda atrás en la tarea anterior. Los revisores que cambian de contexto entre muchos pull requests pequeños arrastran residuo de cada uno hacia el siguiente. La quinta revisión del día se realiza con una fracción del enfoque disponible para la primera. El trabajo se ve igual en el papel; la calidad de la atención no.
+
+### Sesgo de automatización
+
+Los humanos tienden a confiar en la salida automatizada más de lo que deberían, sobre todo cuando es fluida y normalmente correcta. Después de aprobar veinte pull requests de agentes que estaban bien, la expectativa del revisor se desplaza hacia "este probablemente también está bien". El número veintiuno, el que tiene la falla sutil de autorización, pasa sin problemas. Esta es la misma dinámica que discutí en [seguridad y cumplimiento para flujos de trabajo agénticos](/blog/security-compliance-agentic-workflows): el defecto peligroso es el que llega envuelto en el mismo empaque seguro de sí mismo que todo lo que vino antes.
+
+### Disminución de la vigilancia
+
+La atención sostenida se degrada con el tiempo. Este es un efecto medido en cualquier tarea que requiera vigilar problemas poco frecuentes. La revisión de código es exactamente ese tipo de tarea: la mayoría de las líneas están bien y el revisor caza las pocas que no lo están. Cuanto más larga es la sesión, más cae la tasa de detección. El alto volumen de agentes convierte la revisión en una larga tarea de vigilancia, que es precisamente la condición en la que la atención humana es menos confiable.
+
+Junta estos cuatro efectos y llegas a una conclusión clara: **decirle a los revisores que "simplemente revisen con más cuidado" no es una estrategia.** Le pide a personas cansadas que luchen contra su propia neurología a escala. La solución no es más fuerza de voluntad humana. Es un sistema que reduce lo que llega al humano, precalifica lo que llega y protege la atención del revisor para las decisiones que de verdad necesitan a una persona.
+
+---
+
+## Principio: que el humano sea la última línea, no la única línea
+
+En un flujo de trabajo agéntico saludable, un revisor humano debería ser el punto de control final, no el primer filtro. Todo lo que pueda verificarse de forma mecánica o por otro agente debería verificarse antes de que una persona mire el cambio. Para cuando un pull request llega a un humano, tres cosas ya deberían ser ciertas:
+
+1. Ha pasado cada verificación determinista (compilación, pruebas, lint, análisis de seguridad, política).
+2. Ha sido revisado por al menos un agente revisor que no lo escribió.
+3. Ha sido enrutado por riesgo, de modo que el esfuerzo del humano corresponda a lo que está en juego.
+
+El resto de este artículo cubre cómo construir ese sistema: patrones de delegación que dan forma a la entrada, agentes que revisan a otros agentes y arquitecturas de control que enrutan el trabajo por riesgo.
+
+---
+
+## Patrones para la delegación
+
+Delegar no es solo "darle una tarea al agente". Bien hecho, da forma al trabajo para que lo que regresa esté listo para revisar. El objetivo son cambios menos numerosos, con más contexto y mejor explicados, en lugar de una avalancha de cambios opacos.
+
+| Patrón | Qué hace | Por qué reduce la fatiga |
+|---|---|---|
+| **Delegación con especificación primero** | Dar al agente una especificación escrita con criterios de aceptación antes de que escriba código | El revisor compara la salida con una intención conocida en lugar de adivinar para qué era el cambio |
+| **Alcance acotado** | Limitar cada tarea a un solo asunto o módulo | Modelo mental más pequeño por revisión; menos contexto que reconstruir |
+| **Salida autodocumentada** | Exigir al agente que produzca un resumen del cambio, su justificación y una lista de los riesgos que consideró | El revisor parte del razonamiento del autor en lugar de un contexto vacío |
+| **Agrupar por tema, no por tiempo** | Agrupar cambios relacionados en un solo pull request coherente en vez de muchos goteando | Menos cambios de contexto; menos residuo de atención |
+| **Evidencia de pruebas requerida** | Exigir al agente que adjunte resultados de pruebas y explique qué verifica cada una | El revisor evalúa evidencia, no solo afirmaciones de cobertura |
+| **Reversibilidad por defecto** | Preferir cambios detrás de banderas o en módulos aislados | Menos en juego por revisión significa que el humano puede avanzar con más confianza |
+
+El patrón de especificación primero es el de mayor apalancamiento. Como argumenté en [de prompts a especificaciones](/blog/from-prompts-to-specifications), una especificación duradera y versionada da al revisor un punto de referencia fijo. La revisión se convierte entonces en una comparación ("¿coincide esto con la especificación?") en lugar de una investigación abierta ("¿qué es esto y es correcto?"). Ese único cambio transforma la naturaleza cognitiva de la tarea, de reconstrucción a verificación, que es mucho menos agotadora.
+
+Una regla práctica: **si un cambio no se puede explicar en un resumen breve, es demasiado grande para revisarlo bien.** Usa eso como una restricción de delegación, no solo como una queja de revisión.
+
+---
+
+## Agentes que evalúan a otros agentes
+
+Si el problema de volumen viene de los agentes, parte de la solución también viene de los agentes. Un agente que no escribió el código puede servir como primer revisor y atrapar una buena parte de los problemas antes de que un humano gaste atención alguna.
+
+No se trata de reemplazar el juicio humano. Se trata de filtrar, para que el juicio humano se gaste donde importa. Algunos patrones funcionan bien en la práctica.
+
+### El agente revisor
+
+Un agente revisor dedicado lee el cambio con un objetivo distinto al del autor. Donde el autor optimizó para "que funcione", el revisor optimiza para "encontrar lo que está mal". Los agentes personalizados hacen esto concreto: como describí en [construir tu equipo de agentes de IA](/blog/building-your-ai-agent-team), puedes definir un agente `Security Reviewer` que aplique tus políticas, busque clases comunes de vulnerabilidades y valide el manejo de entradas antes de que cualquier código llegue a una persona.
+
+### Revisión adversarial
+
+El autor y el revisor no deberían ser el mismo agente, e idealmente tampoco la misma configuración de modelo. Un agente que revisa su propia salida hereda sus propios puntos ciegos. Un agente revisor distinto, al que se le da la especificación y el diff pero no el razonamiento del autor, aborda el cambio en frío y tiene más probabilidades de notar las brechas. Esta separación entre autor y crítico es la versión agéntica de "no revises tu propio pull request".
+
+### Agentes revisores especializados
+
+Distintas preocupaciones se benefician de distintos revisores. En lugar de un agente que verifica todo de forma superficial, un conjunto de agentes enfocados verifica cada uno una dimensión en profundidad.
+
+| Agente revisor | Enfoque | Verificaciones de ejemplo |
+|---|---|---|
+| **Revisor de seguridad** | Clases de vulnerabilidad y límites de confianza | Validación de entradas, brechas de autenticación/autorización, manejo de secretos, riesgos de inyección |
+| **Revisor de arquitectura** | Ajuste con los patrones existentes | Capas, dirección de dependencias, convenciones de nombres y estructura |
+| **Revisor de pruebas** | Calidad de la verificación, no solo cobertura | Aserciones significativas, casos límite, pruebas que realmente ejercitan el cambio |
+| **Revisor de dependencias** | Integridad de la cadena de suministro | Paquetes nuevos, versiones fijadas, paquetes que no existen en ningún registro |
+| **Revisor de rendimiento** | Implicaciones de costo y latencia | Consultas N+1, bucles sin límite, asignaciones en rutas calientes |
+
+### La trampa que hay que evitar
+
+Los agentes revisores pueden producir su propio sesgo de automatización. Si un agente revisor aprueba un cambio, un humano puede sellarlo sin más precisamente porque un agente ya lo miró. Protégete contra esto tratando la revisión del agente como un filtro que elimina problemas evidentes, no como un aval que pone fin al escrutinio. El agente revisor reduce el volumen y saca a la luz preocupaciones; el humano sigue siendo el dueño de la decisión en todo lo que el sistema marque como de alto riesgo.
+
+Un encuadre útil: los agentes revisores manejan la amplitud (verificar todo, siempre, sin fatiga) y los humanos manejan la profundidad (juicio, contexto y responsabilidad sobre los cambios que importan).
+
+---
+
+## Arquitecturas para la seguridad y la calidad: control por riesgo
+
+La pieza final es estructural. No todos los cambios merecen el mismo escrutinio, y tratarlos a todos por igual es como los revisores se ahogan. Una arquitectura de control basada en riesgo enruta cada cambio por un camino proporcional a su potencial radio de impacto.
+
+El principio hace eco del cambio que describí en [CI/CD para la era agéntica](/blog/cicd-pipelines-agentic-era): el pipeline deja de ser un control uniforme y se convierte en un enrutador activo y consciente del riesgo.
+
+```mermaid
+flowchart TD
+    A[El agente produce el cambio] --> B{Controles deterministas}
+    B -- falla --> R[Devolver al agente con los hallazgos]
+    B -- pasa --> C[Agentes revisores: seguridad, arquitectura, pruebas]
+    C -- preocupaciones encontradas --> R
+    C -- limpio --> D{Clasificación de riesgo}
+    D -- riesgo bajo --> E[Fusión automática con registro de auditoría]
+    D -- riesgo medio --> F[Revisión humana ligera]
+    D -- riesgo alto --> G[Revisión humana profunda + segundo aprobador]
+    E --> H[Desplegar]
+    F --> H
+    G --> H
+```
+
+### Capa 1: controles deterministas
+
+Estos se ejecutan primero y no requieren juicio humano ni de agentes. Compilación, pruebas unitarias y de integración, lint, análisis estático, escaneo de secretos, verificación de vulnerabilidades de dependencias y política como código. Todo lo que falle aquí se devuelve automáticamente al agente autor, con los hallazgos, para que corrija y reenvíe. No se gasta atención humana en problemas detectables de forma mecánica.
+
+### Capa 2: revisión por agentes
+
+Los cambios que pasan los controles deterministas van a los agentes revisores especializados descritos arriba. Su trabajo es eliminar el siguiente nivel de problemas: los que necesitan comprensión pero no necesariamente juicio humano. Su salida no es solo aprobar o rechazar; es un conjunto estructurado de hallazgos y una señal de riesgo que alimenta la siguiente capa.
+
+### Capa 3: clasificación de riesgo y enrutamiento
+
+Esta es la capa que a la mayoría de los equipos les falta. Antes de involucrar a un humano, clasifica el cambio por riesgo y enrútalo en consecuencia. Entradas útiles para la clasificación:
+
+| Señal | Aumenta el riesgo |
+|---|---|
+| **Radio de impacto** | Toca autenticación, pagos, borrado de datos, infraestructura o APIs públicas |
+| **Superficie** | Cambia límites de seguridad, permisos o contratos de cara al exterior |
+| **Reversibilidad** | Difícil de revertir, o ejecuta una migración irreversible |
+| **Novedad** | Introduce una nueva dependencia, patrón o servicio en vez de seguir uno existente |
+| **Confianza del agente** | El agente autor o revisor marcó incertidumbre o compensaciones sin resolver |
+
+Un cambio de bajo riesgo (una corrección de texto, un cambio bien probado detrás de una bandera en un módulo aislado) puede fusionarse automáticamente con un rastro de auditoría completo. Un cambio de riesgo medio recibe una revisión humana ligera. Un cambio de alto riesgo recibe una revisión humana profunda y un segundo aprobador. La escasa atención del humano ahora se gasta en proporción a lo que está en juego, no repartida de forma uniforme sobre una avalancha.
+
+### Capa 4: la decisión humana
+
+Para cuando un cambio llega a una persona, los problemas evidentes ya no están, el cambio está explicado y el riesgo está etiquetado. El humano ya no es un procesador de volumen. Es un juez que aplica contexto y responsabilidad al pequeño conjunto de decisiones que realmente lo requieren. Ese es el papel en el que los humanos son buenos, y el papel para el que deberían ser protegidos.
+
+---
+
+## Consejos prácticos para superar la fatiga del revisor
+
+Más allá de la arquitectura, un conjunto de prácticas concretas mantiene efectivos a los revisores en el día a día.
+
+- **Limita la duración de las sesiones de revisión.** La vigilancia se degrada con el tiempo. Sesiones de revisión más cortas y enfocadas, con pausas, detectan más problemas que las colas maratónicas. Trata el tiempo de revisión como un recurso finito y de alto valor, no como una actividad de fondo apretujada entre reuniones.
+- **Fija un límite diario por revisor.** Si la cola supera lo que un humano puede revisar bien, la respuesta no es un revisor heroico. Es más filtrado por agentes, mejor agrupación o más fusión automática para cambios de bajo riesgo. Una cola que crece es una señal para arreglar el sistema, no para exigir más a la persona.
+- **Haz que los agentes se expliquen.** Exige que cada cambio de un agente incluya qué hizo, por qué y de qué no estaba seguro. Un revisor que parte del razonamiento del autor gasta su energía en verificar, no en reconstruir.
+- **Separa los agentes autor y revisor.** Nunca dejes que el agente que escribió el código sea el único que lo revise. La revisión en frío por un agente distinto atrapa lo que la autorrevisión pasa por alto.
+- **Rota a los revisores en áreas sensibles.** La familiaridad alimenta el sesgo de automatización. Ojos frescos en las rutas críticas de seguridad restauran la vigilancia que la rutina erosiona.
+- **Registra lo que se cuela.** Cuando un defecto escapa a la revisión, haz un análisis sin culpa: qué control debió haberlo atrapado y por qué no lo hizo. Realimenta eso en los controles deterministas y en los agentes revisores para que la misma clase de problema se atrape automáticamente la próxima vez.
+- **Predetermina lo pequeño y reversible.** La revisión más fácil es la que tiene poco en juego. Las banderas, los módulos aislados y los cambios incrementales permiten que los revisores avancen rápido sin cargar riesgo.
+- **Dale al revisor la especificación.** Un revisor que compara un cambio con una especificación clara trabaja mucho más rápido, y de forma mucho más confiable, que uno que infiere la intención solo a partir del diff.
+
+---
+
+## Cómo medir si está funcionando
+
+No puedes gestionar la fatiga del revisor si no puedes verla. Algunas señales te dicen si el sistema está sano o si el humano se está convirtiendo en silencio en el cuello de botella.
+
+| Señal | Qué te dice | Señal de alerta |
+|---|---|---|
+| **Profundidad y antigüedad de la cola de revisión** | Si los revisores van al día | Una cola que crece y envejece significa que el sistema está sobrecargando a los humanos |
+| **Tiempo en revisión por cambio** | Si los cambios están listos para revisar | Un tiempo de revisión que sube sugiere mala delegación o cambios demasiado grandes |
+| **Correlación entre aprobaciones e incidentes** | Si la velocidad cuesta calidad | Aprobaciones rápidas seguidas de incidentes indican sellos sin revisar |
+| **Tasa de escape de defectos** | Si la revisión de verdad atrapa problemas | Una tasa de escape que sube significa que los controles o la atención están fallando |
+| **Distribución de la carga entre revisores** | Si la fatiga está concentrada | Una o dos personas cargando la cola es un riesgo de agotamiento |
+| **Tasa de fusión automática para cambios de bajo riesgo** | Si el sistema protege la atención humana | Una tasa cercana a cero significa que los humanos revisan cosas que no los necesitan |
+
+El patrón más saludable: la mayoría de los cambios de bajo riesgo se fusionan automáticamente de forma segura, los agentes revisores absorben la amplitud y los revisores humanos gastan su tiempo en un pequeño número de decisiones genuinamente importantes con su atención intacta. Como señalé al [medir la productividad del desarrollador](/blog/measuring-developer-productivity-ai-era), la verdadera pregunta no es si entregas más rápido, sino si entregas mejores resultados, de forma más segura y sostenible.
+
+---
+
+## Reflexiones finales
+
+Los agentes abarataron la escritura de código y, al hacerlo, movieron la restricción al humano que tiene que leerlo. La fatiga del revisor es la consecuencia previsible, y no se resuelve pidiéndole a las personas que se esfuercen más. Se resuelve diseñando un sistema que respete los límites de la atención humana.
+
+La forma de ese sistema es consistente: delega para que la entrada esté lista para revisar, deja que los agentes manejen la amplitud de la revisión, controla por riesgo para que el esfuerzo humano corresponda a lo que está en juego y protege la atención del revisor como el recurso escaso que es. Mantén al humano firmemente en el ciclo, pero ponlo al final del ciclo, como el juicio final y no como el primer filtro.
+
+Los equipos que prosperen en la era agéntica no serán los que generen más código. Serán los que puedan revisarlo bien, de forma sostenible, sin agotar a las personas cuyo juicio sigue importando más.

--- a/i18n/pt/docusaurus-plugin-content-blog/2026-06-25-ReviewerFatigue.mdx
+++ b/i18n/pt/docusaurus-plugin-content-blog/2026-06-25-ReviewerFatigue.mdx
@@ -1,0 +1,225 @@
+---
+title: "Fadiga do revisor: quando os agentes escrevem mais código do que os humanos conseguem ler"
+description: "Os agentes de IA já escrevem código mais rápido do que os humanos conseguem revisar. À medida que a escrita acelera, o gargalo se desloca para o humano dentro do ciclo. Este artigo analisa o custo cognitivo de revisar código gerado por agentes e oferece padrões práticos de delegação, agentes que avaliam outros agentes e arquiteturas de controle em camadas que protegem a segurança e a qualidade sem esgotar seus revisores."
+slug: reviewer-fatigue-human-in-the-loop-bottleneck
+authors: [dsanchezcr]
+tags: [AI, Agentic AI, Code Review, Software Engineering, DevOps, Developer Productivity, Engineering Leadership]
+enableComments: true
+hide_table_of_contents: true
+image: https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-25-reviewer-fatigue/reviewer-fatigue.jpg
+date: 2026-06-25T10:00
+---
+
+# Fadiga do revisor: quando os agentes escrevem mais código do que os humanos conseguem ler
+
+## O gargalo se moveu e a maioria das equipes não percebeu
+
+Por décadas, escrever código foi a parte cara. Lê-lo era quase de graça em comparação. Um desenvolvedor passava horas produzindo uma alteração e um revisor passava minutos confirmando-a. Essa proporção moldou tudo: nossas ferramentas, nossos processos e nossa noção de quem estava ocupado e quem estava esperando.
+
+Os agentes inverteram essa proporção. Um agente capaz agora produz uma branch completa com código, testes e documentação no tempo que leva para escrever uma boa descrição da tarefa. Escrever ficou barato. Ler não.
+
+{/* truncate */}
+
+![Fadiga do revisor](https://dsanchezcrwebsite.blob.core.windows.net/images/blog/2026-06-25-reviewer-fatigue/reviewer-fatigue.jpg)
+
+O resultado é um acúmulo silencioso. Os pull requests chegam mais rápido do que qualquer humano consegue absorver. A fila cresce. O revisor, que costumava ser a parte rápida do ciclo, agora é a parte lenta. A restrição não desapareceu quando escrever ficou mais rápido. Ela simplesmente se deslocou para o único lugar que não acelerou: a pessoa que precisa entender, verificar e assumir a responsabilidade pela alteração.
+
+Isso é a fadiga do revisor, e é o gargalo que define a engenharia de software agêntica. Este artigo se concentra no humano ao final de todos esses pipelines e em como manter essa pessoa eficaz quando o volume de trabalho que chega até ela continua crescendo.
+
+---
+
+## A assimetria que ninguém orçou
+
+Escrever e revisar não são imagens espelhadas da mesma tarefa. Elas impõem demandas muito diferentes ao cérebro, e essa diferença é a raiz do problema.
+
+Quando você escreve código, constrói um modelo mental à medida que avança. Cada decisão é sua. Você sabe por que uma variável existe, por que uma ramificação foi adicionada, por que uma dependência foi escolhida. O contexto vive na sua cabeça porque você o colocou ali.
+
+Quando você revisa código, precisa reconstruir esse modelo mental de fora, sem nada do contexto original. Você está fazendo engenharia reversa da intenção a partir dos artefatos. Você precisa perguntar: o que isto tentava fazer, ele realmente faz isso e o que pode dar errado que o autor não considerou.
+
+Revisar código gerado por agentes é ainda mais difícil, por três razões:
+
+1. **Não há contexto compartilhado.** Um autor humano pode responder "por que você fez isto?" em um tópico de comentários. O raciocínio de um agente, se é que existe, muitas vezes é descartado após a geração. Ao revisor resta a saída e nenhum autor para interrogar.
+2. **O código parece seguro de si.** A saída do agente é fluente, bem formatada e plausível. Raramente parece errada. A fluência não é correção, mas se lê como tal, e isso baixa a guarda do revisor.
+3. **O volume é implacável.** Um autor humano produz alguns poucos pull requests por dia. Uma equipe de agentes pode produzir dezenas. O revisor não enfrenta uma tarefa exigente, mas um fluxo contínuo delas.
+
+A verdade incômoda: o ganho de velocidade dos agentes é em parte uma ilusão se ele apenas transfere o trabalho de um autor cansado para um revisor cansado. Como observei ao [medir a produtividade do desenvolvedor](/blog/measuring-developer-productivity-ai-era), uma ferramenta que gera código mais rápido mas obriga os engenheiros a passar mais tempo revisando-o não é um ganho líquido.
+
+---
+
+## A ciência cognitiva da fadiga do revisor
+
+Para projetar boas soluções, ajuda entender exatamente o que está desgastando os revisores. Quatro efeitos cognitivos bem documentados se acumulam sob a revisão de alto volume de agentes.
+
+### Carga cognitiva
+
+A memória de trabalho é pequena. Revisar uma alteração significa segurar na cabeça, ao mesmo tempo, o código afetado, o sistema ao redor, os requisitos e os possíveis modos de falha. Cada pull request reinicia essa carga. Um revisor que processa dez pull requests de agentes em sequência não está fazendo uma tarefa difícil dez vezes. Ele está carregando e descarregando repetidamente modelos mentais completos, o que é muito mais cansativo do que a contagem de linhas sugere.
+
+### Resíduo de atenção
+
+Quando você muda de uma tarefa para outra, parte da sua atenção fica para trás na tarefa anterior. Os revisores que mudam de contexto entre muitos pull requests pequenos arrastam resíduo de cada um para o próximo. A quinta revisão do dia é feita com uma fração do foco disponível para a primeira. O trabalho parece igual no papel; a qualidade da atenção não.
+
+### Viés de automação
+
+Os humanos tendem a confiar na saída automatizada mais do que deveriam, sobretudo quando ela é fluente e normalmente correta. Depois de aprovar vinte pull requests de agentes que estavam corretos, a expectativa do revisor se desloca para "este provavelmente também está certo". O número vinte e um, aquele com a falha sutil de autorização, passa sem problemas. Essa é a mesma dinâmica que discuti em [segurança e conformidade para fluxos de trabalho agênticos](/blog/security-compliance-agentic-workflows): o defeito perigoso é o que chega embrulhado na mesma embalagem segura de si de tudo o que veio antes.
+
+### Queda de vigilância
+
+A atenção sustentada se degrada com o tempo. Esse é um efeito medido em qualquer tarefa que exija vigiar problemas raros. A revisão de código é exatamente esse tipo de tarefa: a maioria das linhas está correta e o revisor caça as poucas que não estão. Quanto mais longa a sessão, mais cai a taxa de detecção. O alto volume de agentes transforma a revisão em uma longa tarefa de vigilância, que é justamente a condição em que a atenção humana é menos confiável.
+
+Junte esses quatro efeitos e você chega a uma conclusão clara: **dizer aos revisores para "simplesmente revisar com mais cuidado" não é uma estratégia.** Isso pede a pessoas cansadas que lutem contra a própria neurologia em escala. A correção não é mais força de vontade humana. É um sistema que reduz o que chega ao humano, pré-qualifica o que chega e protege a atenção do revisor para as decisões que de fato precisam de uma pessoa.
+
+---
+
+## Princípio: que o humano seja a última linha, não a única linha
+
+Em um fluxo de trabalho agêntico saudável, um revisor humano deveria ser o ponto de controle final, não o primeiro filtro. Tudo o que pode ser verificado de forma mecânica ou por outro agente deveria ser verificado antes de uma pessoa olhar a alteração. No momento em que um pull request chega a um humano, três coisas já deveriam ser verdadeiras:
+
+1. Ele passou por todas as verificações determinísticas (compilação, testes, lint, análise de segurança, política).
+2. Ele foi revisado por pelo menos um agente revisor que não o escreveu.
+3. Ele foi roteado por risco, de modo que o esforço do humano corresponda ao que está em jogo.
+
+O restante deste artigo cobre como construir esse sistema: padrões de delegação que moldam a entrada, agentes que revisam outros agentes e arquiteturas de controle que roteiam o trabalho por risco.
+
+---
+
+## Padrões para a delegação
+
+Delegar não é apenas "dar uma tarefa ao agente". Bem feito, isso molda o trabalho para que o que volta esteja pronto para revisão. O objetivo são alterações menos numerosas, com mais contexto e melhor explicadas, em vez de uma avalanche de alterações opacas.
+
+| Padrão | O que faz | Por que reduz a fadiga |
+|---|---|---|
+| **Delegação com especificação primeiro** | Dar ao agente uma especificação escrita com critérios de aceitação antes que ele escreva código | O revisor compara a saída com uma intenção conhecida em vez de adivinhar para que servia a alteração |
+| **Escopo delimitado** | Limitar cada tarefa a um único assunto ou módulo | Modelo mental menor por revisão; menos contexto a reconstruir |
+| **Saída autodocumentada** | Exigir do agente um resumo da alteração, sua justificativa e uma lista dos riscos que considerou | O revisor parte do raciocínio do autor em vez de um contexto vazio |
+| **Agrupar por tema, não por tempo** | Agrupar alterações relacionadas em um único pull request coerente em vez de muitos pingando | Menos trocas de contexto; menos resíduo de atenção |
+| **Evidência de testes exigida** | Exigir que o agente anexe resultados de testes e explique o que cada um verifica | O revisor avalia evidências, não apenas afirmações de cobertura |
+| **Reversibilidade por padrão** | Preferir alterações atrás de flags ou em módulos isolados | Menos em jogo por revisão significa que o humano pode avançar com mais confiança |
+
+O padrão de especificação primeiro é o de maior alavancagem. Como argumentei em [de prompts a especificações](/blog/from-prompts-to-specifications), uma especificação durável e versionada dá ao revisor um ponto de referência fixo. A revisão então se torna uma comparação ("isto corresponde à especificação?") em vez de uma investigação aberta ("o que é isto e está correto?"). Essa única mudança transforma a natureza cognitiva da tarefa, de reconstrução para verificação, que é muito menos exaustiva.
+
+Uma regra prática: **se uma alteração não pode ser explicada em um resumo curto, ela é grande demais para ser bem revisada.** Use isso como uma restrição de delegação, não apenas como uma reclamação de revisão.
+
+---
+
+## Agentes que avaliam outros agentes
+
+Se o problema de volume vem dos agentes, parte da solução também vem dos agentes. Um agente que não escreveu o código pode servir como primeiro revisor e capturar uma boa parte dos problemas antes que um humano gaste qualquer atenção.
+
+Não se trata de substituir o julgamento humano. Trata-se de filtrar, para que o julgamento humano seja gasto onde importa. Alguns padrões funcionam bem na prática.
+
+### O agente revisor
+
+Um agente revisor dedicado lê a alteração com um objetivo diferente do autor. Onde o autor otimizou para "fazer funcionar", o revisor otimiza para "encontrar o que está errado". Os agentes personalizados tornam isso concreto: como descrevi em [montar sua equipe de agentes de IA](/blog/building-your-ai-agent-team), você pode definir um agente `Security Reviewer` que aplica suas políticas, busca classes comuns de vulnerabilidades e valida o tratamento de entradas antes que qualquer código chegue a uma pessoa.
+
+### Revisão adversarial
+
+O autor e o revisor não deveriam ser o mesmo agente, e idealmente nem a mesma configuração de modelo. Um agente que revisa a própria saída herda os próprios pontos cegos. Um agente revisor distinto, ao qual se dá a especificação e o diff mas não o raciocínio do autor, aborda a alteração a frio e tem mais chances de notar as lacunas. Essa separação entre autor e crítico é a versão agêntica de "não revise o seu próprio pull request".
+
+### Agentes revisores especializados
+
+Diferentes preocupações se beneficiam de diferentes revisores. Em vez de um agente que verifica tudo de forma superficial, um conjunto de agentes focados verifica cada um uma dimensão em profundidade.
+
+| Agente revisor | Foco | Verificações de exemplo |
+|---|---|---|
+| **Revisor de segurança** | Classes de vulnerabilidade e limites de confiança | Validação de entradas, lacunas de autenticação/autorização, tratamento de segredos, riscos de injeção |
+| **Revisor de arquitetura** | Encaixe com os padrões existentes | Camadas, direção das dependências, convenções de nomes e estrutura |
+| **Revisor de testes** | Qualidade da verificação, não apenas cobertura | Asserções significativas, casos de borda, testes que de fato exercitam a alteração |
+| **Revisor de dependências** | Integridade da cadeia de suprimentos | Pacotes novos, versões fixadas, pacotes que não existem em nenhum registro |
+| **Revisor de desempenho** | Implicações de custo e latência | Consultas N+1, laços sem limite, alocações em caminhos quentes |
+
+### A armadilha a evitar
+
+Os agentes revisores podem produzir o próprio viés de automação. Se um agente revisor aprova uma alteração, um humano pode carimbá-la sem mais justamente porque um agente já olhou. Proteja-se disso tratando a revisão do agente como um filtro que remove problemas evidentes, não como um aval que encerra o escrutínio. O agente revisor reduz o volume e traz à tona preocupações; o humano continua sendo o dono da decisão em tudo o que o sistema marcar como de alto risco.
+
+Um enquadramento útil: os agentes revisores cuidam da amplitude (verificar tudo, sempre, sem fadiga) e os humanos cuidam da profundidade (julgamento, contexto e responsabilidade sobre as alterações que importam).
+
+---
+
+## Arquiteturas para segurança e qualidade: controle por risco
+
+A peça final é estrutural. Nem toda alteração merece o mesmo escrutínio, e tratar todas igualmente é como os revisores se afogam. Uma arquitetura de controle baseada em risco roteia cada alteração por um caminho proporcional ao seu potencial raio de impacto.
+
+O princípio ecoa a mudança que descrevi em [CI/CD para a era agêntica](/blog/cicd-pipelines-agentic-era): o pipeline deixa de ser um controle uniforme e se torna um roteador ativo e consciente do risco.
+
+```mermaid
+flowchart TD
+    A[O agente produz a alteração] --> B{Controles determinísticos}
+    B -- falha --> R[Devolver ao agente com as descobertas]
+    B -- passa --> C[Agentes revisores: segurança, arquitetura, testes]
+    C -- preocupações encontradas --> R
+    C -- limpo --> D{Classificação de risco}
+    D -- risco baixo --> E[Merge automático com registro de auditoria]
+    D -- risco médio --> F[Revisão humana leve]
+    D -- risco alto --> G[Revisão humana profunda + segundo aprovador]
+    E --> H[Implantar]
+    F --> H
+    G --> H
+```
+
+### Camada 1: controles determinísticos
+
+Estes rodam primeiro e não exigem julgamento humano nem de agentes. Compilação, testes unitários e de integração, lint, análise estática, varredura de segredos, verificação de vulnerabilidades de dependências e política como código. Tudo o que falha aqui é devolvido automaticamente ao agente autor, com as descobertas, para que corrija e reenvie. Nenhuma atenção humana é gasta em problemas detectáveis de forma mecânica.
+
+### Camada 2: revisão por agentes
+
+As alterações que passam pelos controles determinísticos vão para os agentes revisores especializados descritos acima. O trabalho deles é remover o próximo nível de problemas: aqueles que precisam de compreensão mas não necessariamente de julgamento humano. A saída deles não é apenas aprovar ou rejeitar; é um conjunto estruturado de descobertas e um sinal de risco que alimenta a próxima camada.
+
+### Camada 3: classificação de risco e roteamento
+
+Esta é a camada que falta à maioria das equipes. Antes de envolver um humano, classifique a alteração por risco e roteie de acordo. Entradas úteis para a classificação:
+
+| Sinal | Aumenta o risco |
+|---|---|
+| **Raio de impacto** | Toca autenticação, pagamentos, exclusão de dados, infraestrutura ou APIs públicas |
+| **Superfície** | Altera limites de segurança, permissões ou contratos voltados ao exterior |
+| **Reversibilidade** | Difícil de reverter, ou executa uma migração irreversível |
+| **Novidade** | Introduz uma nova dependência, padrão ou serviço em vez de seguir um existente |
+| **Confiança do agente** | O agente autor ou revisor sinalizou incerteza ou compensações não resolvidas |
+
+Uma alteração de baixo risco (uma correção de texto, uma alteração bem testada atrás de uma flag em um módulo isolado) pode passar por merge automático com uma trilha de auditoria completa. Uma alteração de risco médio recebe uma revisão humana leve. Uma alteração de alto risco recebe uma revisão humana profunda e um segundo aprovador. A escassa atenção do humano agora é gasta em proporção ao que está em jogo, não espalhada de forma uniforme sobre uma avalanche.
+
+### Camada 4: a decisão humana
+
+No momento em que uma alteração chega a uma pessoa, os problemas evidentes já não estão lá, a alteração está explicada e o risco está rotulado. O humano já não é um processador de volume. É um juiz que aplica contexto e responsabilidade ao pequeno conjunto de decisões que realmente exigem isso. Esse é o papel em que os humanos são bons, e o papel para o qual deveriam ser protegidos.
+
+---
+
+## Dicas práticas para superar a fadiga do revisor
+
+Além da arquitetura, um conjunto de práticas concretas mantém os revisores eficazes no dia a dia.
+
+- **Limite a duração das sessões de revisão.** A vigilância se degrada com o tempo. Sessões de revisão mais curtas e focadas, com pausas, detectam mais problemas do que filas maratonas. Trate o tempo de revisão como um recurso finito e de alto valor, não como uma atividade de fundo espremida entre reuniões.
+- **Defina um limite diário por revisor.** Se a fila excede o que um humano consegue revisar bem, a resposta não é um revisor heroico. É mais filtragem por agentes, melhor agrupamento ou mais merge automático para alterações de baixo risco. Uma fila que cresce é um sinal para consertar o sistema, não para exigir mais da pessoa.
+- **Faça os agentes se explicarem.** Exija que cada alteração de um agente inclua o que ele fez, por quê e sobre o que ficou em dúvida. Um revisor que parte do raciocínio do autor gasta a energia verificando, não reconstruindo.
+- **Separe os agentes autor e revisor.** Nunca deixe que o agente que escreveu o código seja o único a revisá-lo. A revisão a frio por um agente distinto captura o que a autorrevisão deixa passar.
+- **Faça rodízio de revisores em áreas sensíveis.** A familiaridade alimenta o viés de automação. Olhos novos nos caminhos críticos de segurança restauram a vigilância que a rotina corrói.
+- **Registre o que escapa.** Quando um defeito escapa à revisão, faça uma análise sem culpa: qual controle deveria tê-lo capturado e por que não capturou? Realimente isso nos controles determinísticos e nos agentes revisores para que a mesma classe de problema seja capturada automaticamente na próxima vez.
+- **Prefira o pequeno e reversível por padrão.** A revisão mais fácil é a que tem pouco em jogo. Flags, módulos isolados e alterações incrementais permitem que os revisores avancem rápido sem carregar risco.
+- **Dê a especificação ao revisor.** Um revisor que compara uma alteração com uma especificação clara trabalha muito mais rápido, e de forma muito mais confiável, do que um que infere a intenção apenas a partir do diff.
+
+---
+
+## Como medir se está funcionando
+
+Você não consegue gerenciar a fadiga do revisor se não consegue vê-la. Alguns sinais indicam se o sistema está saudável ou se o humano está se tornando, em silêncio, o gargalo.
+
+| Sinal | O que indica | Sinal de alerta |
+|---|---|---|
+| **Profundidade e idade da fila de revisão** | Se os revisores estão dando conta | Uma fila que cresce e envelhece significa que o sistema está sobrecarregando os humanos |
+| **Tempo em revisão por alteração** | Se as alterações estão prontas para revisão | Um tempo de revisão que sobe sugere má delegação ou alterações grandes demais |
+| **Correlação entre aprovações e incidentes** | Se a velocidade está custando qualidade | Aprovações rápidas seguidas de incidentes indicam carimbos sem revisão |
+| **Taxa de escape de defeitos** | Se a revisão de fato captura problemas | Uma taxa de escape que sobe significa que os controles ou a atenção estão falhando |
+| **Distribuição da carga entre revisores** | Se a fadiga está concentrada | Uma ou duas pessoas carregando a fila é um risco de esgotamento |
+| **Taxa de merge automático para alterações de baixo risco** | Se o sistema protege a atenção humana | Uma taxa próxima de zero significa que os humanos revisam coisas que não precisam deles |
+
+O padrão mais saudável: a maioria das alterações de baixo risco passa por merge automático de forma segura, os agentes revisores absorvem a amplitude e os revisores humanos gastam o tempo em um pequeno número de decisões genuinamente importantes com a atenção intacta. Como observei ao [medir a produtividade do desenvolvedor](/blog/measuring-developer-productivity-ai-era), a verdadeira pergunta não é se você entrega mais rápido, mas se você entrega melhores resultados, de forma mais segura e sustentável.
+
+---
+
+## Considerações finais
+
+Os agentes tornaram a escrita de código barata e, ao fazê-lo, moveram a restrição para o humano que precisa lê-lo. A fadiga do revisor é a consequência previsível, e ela não se resolve pedindo às pessoas que se esforcem mais. Ela se resolve projetando um sistema que respeite os limites da atenção humana.
+
+A forma desse sistema é consistente: delegue para que a entrada esteja pronta para revisão, deixe os agentes cuidarem da amplitude da revisão, controle por risco para que o esforço humano corresponda ao que está em jogo e proteja a atenção do revisor como o recurso escasso que ela é. Mantenha o humano firmemente no ciclo, mas coloque-o ao final do ciclo, como o julgamento final e não como o primeiro filtro.
+
+As equipes que prosperarem na era agêntica não serão as que geram mais código. Serão as que conseguem revisá-lo bem, de forma sustentável, sem esgotar as pessoas cujo julgamento ainda importa mais.


### PR DESCRIPTION
Publish a new blog post on reviewer fatigue in agentic software engineering, covering the human review bottleneck, layered gating, and agent-to-agent review patterns. Includes Spanish and Portuguese translations to keep blog i18n coverage in sync.